### PR TITLE
Fix Malware Analysis object

### DIFF
--- a/malware-analysis.go
+++ b/malware-analysis.go
@@ -59,12 +59,24 @@ type MalwareAnalysis struct {
 	AnalysisStarted *Timestamp `json:"analysis_started,omitempty"`
 	// AnalysisEnded is the date and time that the malware analysis ended.
 	AnalysisEnded *Timestamp `json:"analysis_ended,omitempty"`
-	// AVResult is the classification result or name assigned to the malware
+	// ResultName is the classification result or name assigned to the malware
 	// instance by the AV scanner tool.
-	AVResult string `json:"av_result,omitempty"`
+	ResultName string `json:"result_name,omitempty"`
+	// Result is the classification result as determined by the scanner or tool
+	// analysis process.
+	Result string `json:"result,omitempty"`
 	// AnalysisSCOs contains the references to the STIX Cyber-observable
 	// Objects that were captured during the analysis process.
 	AnalysisSCOs []Identifier `json:"analysis_sco_refs,omitempty"`
+	// Sample contains the reference to the SCO file, network traffic or
+	// artifact object that this malware analysis was performed against.
+	// Caution should be observed when creating an SRO between Malware and
+	// Malware Analysis objects when the Malware sample_refs property does not
+	// contain the SCO that is included in the Malware Analysis sample_ref
+	// property.  Note, this property can also contain a reference to an SCO
+	// which is not associated with Malware (i.e., some SCO which was scanned
+	// and found to be benign.)
+	Sample Identifier `json:"sample_ref,omitempty"`
 }
 
 // AddCharacterizes describes that the malware analysis is describes the
@@ -114,7 +126,7 @@ func NewMalwareAnalysis(product, result string, analysisSCOs []Identifier, opts 
 		STIXDomainObject: base,
 		Product:          product,
 		AnalysisSCOs:     analysisSCOs,
-		AVResult:         result,
+		Result:           result,
 	}
 
 	for _, opt := range opts {
@@ -295,16 +307,29 @@ func MalwareAnalysisOptionAnalysisEnded(s *Timestamp) MalwareAnalysisOption {
 	}
 }
 
+// MalwareAnalysisOptionResultName sets the analysis result name attribute.
+func MalwareAnalysisOptionResultName(s string) MalwareAnalysisOption {
+	return func(obj *MalwareAnalysis) {
+		obj.ResultName = s
+	}
+}
+
+// MalwareAnalysisOptionSample sets the analysis sample attribute.
+func MalwareAnalysisOptionSample(s Identifier) MalwareAnalysisOption {
+	return func(obj *MalwareAnalysis) {
+		obj.Sample = s
+	}
+}
+
 const (
-	// MalwareAVResultMalicious AV tool reported the malware binary as
-	// malicious.
-	MalwareAVResultMalicious = "malicious"
-	// MalwareAVResultSuspicious AV tool reported the malware binary as
+	// MalwareResultMalicious AV tool reported the malware binary as malicious.
+	MalwareResultMalicious = "malicious"
+	// MalwareResultSuspicious AV tool reported the malware binary as
 	// suspicious but not definitively malicious.
-	MalwareAVResultSuspicious = "suspicious"
-	// MalwareAVResultBenign AV tool reported the malware binary as benign.
-	MalwareAVResultBenign = "benign"
-	// MalwareAVResultUnknown AV tool was unable to determine whether the
-	// malware binary is malicious.
-	MalwareAVResultUnknown = "unknown"
+	MalwareResultSuspicious = "suspicious"
+	// MalwareResultBenign AV tool reported the malware binary as benign.
+	MalwareResultBenign = "benign"
+	// MalwareResultUnknown AV tool was unable to determine whether the malware
+	// binary is malicious.
+	MalwareResultUnknown = "unknown"
 )

--- a/malware-analysis_test.go
+++ b/malware-analysis_test.go
@@ -16,7 +16,7 @@ func TestMalwareAnalysis(t *testing.T) {
 	product := "AV Product"
 	ip := NewIdentifier(TypeIPv4Addr)
 	ips := []Identifier{ip}
-	result := MalwareAVResultMalicious
+	result := MalwareResultMalicious
 
 	t.Run("missing_property", func(t *testing.T) {
 		obj, err := NewMalwareAnalysis("", "", []Identifier{}, nil)
@@ -48,9 +48,8 @@ func TestMalwareAnalysis(t *testing.T) {
 		modules := []string{"mod 1", "mod 2"}
 		anenver := "2.2.2"
 		andef := "3.2.2"
-		// langu := []string{ImplementationLanguageGo}
-		// capa := []string{MalwareAnalysisCapabilitiesCommunicatesWithC2}
-		// samples := []Identifier{createdBy}
+		resultName := "Some name"
+		sample := Identifier("something")
 
 		opts := []MalwareAnalysisOption{
 			MalwareAnalysisOptionConfidence(conf),
@@ -76,6 +75,8 @@ func TestMalwareAnalysis(t *testing.T) {
 			MalwareAnalysisOptionSubmitted(ts),
 			MalwareAnalysisOptionAnalysisStarted(ts),
 			MalwareAnalysisOptionAnalysisEnded(ts),
+			MalwareAnalysisOptionResultName(resultName),
+			MalwareAnalysisOptionSample(sample),
 		}
 		obj, err := NewMalwareAnalysis(product, result, ips, opts...)
 		assert.NotNil(obj)
@@ -93,7 +94,7 @@ func TestMalwareAnalysis(t *testing.T) {
 		assert.Equal(specVer, obj.SpecVersion)
 
 		assert.Equal(product, obj.Product)
-		assert.Equal(result, obj.AVResult)
+		assert.Equal(result, obj.Result)
 		assert.Equal(ips, obj.AnalysisSCOs)
 		assert.Equal(ver, obj.Version)
 		assert.Equal(hostVM, obj.HostVM)
@@ -106,6 +107,8 @@ func TestMalwareAnalysis(t *testing.T) {
 		assert.Equal(ts, obj.Submitted)
 		assert.Equal(ts, obj.AnalysisStarted)
 		assert.Equal(ts, obj.AnalysisEnded)
+		assert.Equal(resultName, obj.ResultName)
+		assert.Equal(sample, obj.Sample)
 	})
 }
 
@@ -113,7 +116,7 @@ func TestMalwareAnalysisAddCharacterizes(t *testing.T) {
 	assert := assert.New(t)
 
 	t.Run("characterizes", func(t *testing.T) {
-		obj, err := NewMalwareAnalysis("prod", MalwareAVResultMalicious, []Identifier{})
+		obj, err := NewMalwareAnalysis("prod", MalwareResultMalicious, []Identifier{})
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := obj.AddCharacterizes(id)
@@ -124,7 +127,7 @@ func TestMalwareAnalysisAddCharacterizes(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewMalwareAnalysis("prod", MalwareAVResultMalicious, []Identifier{})
+		obj, err := NewMalwareAnalysis("prod", MalwareResultMalicious, []Identifier{})
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddCharacterizes(id)
@@ -137,7 +140,7 @@ func TestMalwareAnalysisAddAVAnalysisOf(t *testing.T) {
 	assert := assert.New(t)
 
 	t.Run("characterizes", func(t *testing.T) {
-		obj, err := NewMalwareAnalysis("prod", MalwareAVResultMalicious, []Identifier{})
+		obj, err := NewMalwareAnalysis("prod", MalwareResultMalicious, []Identifier{})
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := obj.AddAVAnalysisOf(id)
@@ -148,7 +151,7 @@ func TestMalwareAnalysisAddAVAnalysisOf(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewMalwareAnalysis("prod", MalwareAVResultMalicious, []Identifier{})
+		obj, err := NewMalwareAnalysis("prod", MalwareResultMalicious, []Identifier{})
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddAVAnalysisOf(id)
@@ -161,7 +164,7 @@ func TestMalwareAnalysisAddStaticAnalysisOf(t *testing.T) {
 	assert := assert.New(t)
 
 	t.Run("characterizes", func(t *testing.T) {
-		obj, err := NewMalwareAnalysis("prod", MalwareAVResultMalicious, []Identifier{})
+		obj, err := NewMalwareAnalysis("prod", MalwareResultMalicious, []Identifier{})
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := obj.AddStaticAnalysisOf(id)
@@ -172,7 +175,7 @@ func TestMalwareAnalysisAddStaticAnalysisOf(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewMalwareAnalysis("prod", MalwareAVResultMalicious, []Identifier{})
+		obj, err := NewMalwareAnalysis("prod", MalwareResultMalicious, []Identifier{})
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddStaticAnalysisOf(id)
@@ -185,7 +188,7 @@ func TestMalwareAnalysisAddDynamicAnalysisOf(t *testing.T) {
 	assert := assert.New(t)
 
 	t.Run("characterizes", func(t *testing.T) {
-		obj, err := NewMalwareAnalysis("prod", MalwareAVResultMalicious, []Identifier{})
+		obj, err := NewMalwareAnalysis("prod", MalwareResultMalicious, []Identifier{})
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := obj.AddDynamicAnalysisOf(id)
@@ -196,7 +199,7 @@ func TestMalwareAnalysisAddDynamicAnalysisOf(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewMalwareAnalysis("prod", MalwareAVResultMalicious, []Identifier{})
+		obj, err := NewMalwareAnalysis("prod", MalwareResultMalicious, []Identifier{})
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddDynamicAnalysisOf(id)


### PR DESCRIPTION
* Add new attributes that were added with the release of the spec.
* Change the name of attributes to align with spec.