### PR TITLE
Fix difference between draft and spec

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -109,9 +109,9 @@ func Example() {
 	collection.Add(domain)
 
 	mal, err := stix2.NewMalware(
-		[]string{stix2.MalwareTypeBot},
 		false,
 		stix2.MalwareOptionName("IMDDOS"),
+		stix2.MalwareOptionTypes([]string{stix2.MalwareTypeBot}),
 	)
 	if err != nil {
 		fmt.Println(err)
@@ -120,7 +120,6 @@ func Example() {
 
 	infra, err := stix2.NewInfrastructure(
 		"Example Target List Host",
-		[]string{stix2.InfrastructureTypeHostingTargetLists},
 	)
 	if err != nil {
 		fmt.Println(err)

--- a/file.go
+++ b/file.go
@@ -128,7 +128,7 @@ func NewFile(name string, hashes Hashes, opts ...FileOption) (*File, error) {
 		}
 		opt(obj)
 	}
-	idContri := make([]string, 0, 3)
+	idContri := make([]string, 0, 4)
 	if len(obj.Hashes) != 0 {
 		idContri = append(idContri, obj.Hashes.getIDContribution())
 	}
@@ -137,6 +137,9 @@ func NewFile(name string, hashes Hashes, opts ...FileOption) (*File, error) {
 	}
 	if len(obj.Extensions) != 0 {
 		idContri = append(idContri, obj.canonicalizeExtensions())
+	}
+	if obj.ParentDirectory != "" {
+		idContri = append(idContri, fmt.Sprintf(`"%s"`, obj.ParentDirectory))
 	}
 	obj.ID = NewObservableIdenfier(fmt.Sprintf("[%s]", strings.Join(idContri, ",")), TypeFile)
 	return obj, nil

--- a/file_test.go
+++ b/file_test.go
@@ -86,18 +86,23 @@ func TestFile(t *testing.T) {
 			hash Hashes
 			name string
 			exts *ArchiveFileExtension
+			par  Identifier
 			id   string
 		}{
-			{nil, val, nil, "file--77fc2ec7-ef85-57fa-9d5e-9e77693fc739"},
-			{hash, val, nil, "file--7c5c7956-5343-5a06-9710-db90e1331cac"},
-			{hash, val, ext, "file--893f22f2-e09e-50b6-b481-b94ac9b51a94"},
+			{nil, val, nil, "", "file--77fc2ec7-ef85-57fa-9d5e-9e77693fc739"},
+			{hash, val, nil, "", "file--7c5c7956-5343-5a06-9710-db90e1331cac"},
+			{hash, val, ext, "", "file--893f22f2-e09e-50b6-b481-b94ac9b51a94"},
+			{hash, val, ext, ref, "file--d233087f-68da-5e20-b3cb-42ad9edb401c"},
 		}
 		for _, test := range tests {
-			var opt FileOption
+			opt := make([]FileOption, 0, 2)
 			if test.exts != nil {
-				opt = FileOptionExtension(ExtArchive, test.exts)
+				opt = append(opt, FileOptionExtension(ExtArchive, test.exts))
 			}
-			obj, err := NewFile(test.name, test.hash, opt)
+			if test.par != "" {
+				opt = append(opt, FileOptionParentDirectory(test.par))
+			}
+			obj, err := NewFile(test.name, test.hash, opt...)
 			assert.NoError(err)
 			assert.Equal(Identifier(test.id), obj.ID)
 		}

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=

--- a/identity.go
+++ b/identity.go
@@ -44,12 +44,12 @@ func (c *Identity) AddLocatedAt(id Identifier, opts ...RelationshipOption) (*Rel
 }
 
 // NewIdentity creates a new Identity object.
-func NewIdentity(name, class string, opts ...IdentityOption) (*Identity, error) {
-	if name == "" || class == "" {
+func NewIdentity(name string, opts ...IdentityOption) (*Identity, error) {
+	if name == "" {
 		return nil, ErrPropertyMissing
 	}
 	base := newSTIXDomainObject(TypeIdentity)
-	obj := &Identity{STIXDomainObject: base, Name: name, IdentityClass: class}
+	obj := &Identity{STIXDomainObject: base, Name: name}
 
 	for _, opt := range opts {
 		if opt == nil {
@@ -230,6 +230,13 @@ func IdentityOptionCreatedBy(id Identifier) IdentityOption {
 func IdentityOptionDescription(des string) IdentityOption {
 	return func(obj *Identity) {
 		obj.Description = des
+	}
+}
+
+// IdentityOptionClass sets the identity class attribute.
+func IdentityOptionClass(s string) IdentityOption {
+	return func(obj *Identity) {
+		obj.IdentityClass = s
 	}
 }
 

--- a/identity_test.go
+++ b/identity_test.go
@@ -15,16 +15,15 @@ func TestIdentity(t *testing.T) {
 	assert := assert.New(t)
 
 	name := "New campaign"
-	class := IdentityClassUnspecified
 
 	t.Run("missing_property", func(t *testing.T) {
-		obj, err := NewIdentity("", "")
+		obj, err := NewIdentity("")
 		assert.Nil(obj)
 		assert.Equal(ErrPropertyMissing, err)
 	})
 
 	t.Run("no_optional", func(t *testing.T) {
-		obj, err := NewIdentity(name, class, nil)
+		obj, err := NewIdentity(name, nil)
 		assert.NotNil(obj)
 		assert.NoError(err)
 	})
@@ -42,6 +41,7 @@ func TestIdentity(t *testing.T) {
 		specVer := "2.0"
 
 		roles := []string{"CEO", "Retailer"}
+		class := IdentityClassUnspecified
 		sectors := []string{IdentitySectorDefence, IdentitySectorEntertainment}
 		contact := "123 Main ST"
 
@@ -59,11 +59,12 @@ func TestIdentity(t *testing.T) {
 			IdentityOptionSpecVersion(specVer),
 			//
 			IdentityOptionDescription(desc),
+			IdentityOptionClass(class),
 			IdentityOptionRoles(roles),
 			IdentityOptionSectors(sectors),
 			IdentityOptionContactInformation(contact),
 		}
-		obj, err := NewIdentity(name, class, opts...)
+		obj, err := NewIdentity(name, opts...)
 		assert.NotNil(obj)
 		assert.NoError(err)
 		assert.Equal(conf, obj.Confidence)
@@ -78,6 +79,8 @@ func TestIdentity(t *testing.T) {
 		assert.True(obj.Revoked)
 		assert.Equal(specVer, obj.SpecVersion)
 
+		assert.Equal(name, obj.Name)
+		assert.Equal(class, obj.IdentityClass)
 		assert.Equal(desc, obj.Description)
 		assert.Equal(roles, obj.Roles)
 		assert.Equal(sectors, obj.Sectors)
@@ -114,7 +117,7 @@ func TestIdentityMitigates(t *testing.T) {
 	assert := assert.New(t)
 
 	t.Run("vulnerability", func(t *testing.T) {
-		obj, err := NewIdentity("name", "class")
+		obj, err := NewIdentity("name")
 		assert.NoError(err)
 		id := NewIdentifier(TypeLocation)
 		rel, err := obj.AddLocatedAt(id)
@@ -124,7 +127,7 @@ func TestIdentityMitigates(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewIdentity("name", "class")
+		obj, err := NewIdentity("name")
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddLocatedAt(id)

--- a/indicator.go
+++ b/indicator.go
@@ -69,12 +69,12 @@ func (c *Indicator) AddBasedOn(id Identifier, opts ...RelationshipOption) (*Rela
 }
 
 // NewIndicator creates a new Indicator object.
-func NewIndicator(pattern, patternType string, indicatorTypes []string, validFrom *Timestamp, opts ...IndicatorOption) (*Indicator, error) {
-	if pattern == "" || patternType == "" || len(indicatorTypes) == 0 || validFrom == nil {
+func NewIndicator(pattern, patternType string, validFrom *Timestamp, opts ...IndicatorOption) (*Indicator, error) {
+	if pattern == "" || patternType == "" || validFrom == nil {
 		return nil, ErrPropertyMissing
 	}
 	base := newSTIXDomainObject(TypeIndicator)
-	obj := &Indicator{STIXDomainObject: base, Pattern: pattern, PatternType: patternType, IndicatorTypes: indicatorTypes, ValidFrom: validFrom}
+	obj := &Indicator{STIXDomainObject: base, Pattern: pattern, PatternType: patternType, ValidFrom: validFrom}
 
 	for _, opt := range opts {
 		if opt == nil {
@@ -219,6 +219,13 @@ func IndicatorOptionKillChainPhase(s []*KillChainPhase) IndicatorOption {
 func IndicatorOptionName(s string) IndicatorOption {
 	return func(obj *Indicator) {
 		obj.Name = s
+	}
+}
+
+// IndicatorOptionTypes sets the indicator types attribute.
+func IndicatorOptionTypes(s []string) IndicatorOption {
+	return func(obj *Indicator) {
+		obj.IndicatorTypes = s
 	}
 }
 

--- a/indicator_test.go
+++ b/indicator_test.go
@@ -17,16 +17,15 @@ func TestIndicator(t *testing.T) {
 	pattern := "new pattern"
 	patternType := "stix"
 	ts := &Timestamp{time.Now()}
-	indType := []string{IndicatorTypeCompromised}
 
 	t.Run("missing_property", func(t *testing.T) {
-		obj, err := NewIndicator("", "", []string{}, nil)
+		obj, err := NewIndicator("", "", nil)
 		assert.Nil(obj)
 		assert.Equal(ErrPropertyMissing, err)
 	})
 
 	t.Run("no_optional", func(t *testing.T) {
-		obj, err := NewIndicator(pattern, patternType, indType, ts, nil)
+		obj, err := NewIndicator(pattern, patternType, ts, nil)
 		assert.NotNil(obj)
 		assert.NoError(err)
 	})
@@ -44,6 +43,7 @@ func TestIndicator(t *testing.T) {
 		specVer := "2.0"
 
 		name := "Name"
+		indType := []string{IndicatorTypeCompromised}
 		patVer := "1.0"
 		kchain := []*KillChainPhase{{}}
 
@@ -62,11 +62,12 @@ func TestIndicator(t *testing.T) {
 			//
 			IndicatorOptionDescription(desc),
 			IndicatorOptionName(name),
+			IndicatorOptionTypes(indType),
 			IndicatorOptionKillChainPhase(kchain),
 			IndicatorOptionPatternVersion(patVer),
 			IndicatorOptionValidUntil(ts),
 		}
-		obj, err := NewIndicator(pattern, patternType, indType, ts, opts...)
+		obj, err := NewIndicator(pattern, patternType, ts, opts...)
 		assert.NotNil(obj)
 		assert.NoError(err)
 		assert.Equal(conf, obj.Confidence)
@@ -83,6 +84,7 @@ func TestIndicator(t *testing.T) {
 
 		assert.Equal(desc, obj.Description)
 		assert.Equal(name, obj.Name)
+		assert.Equal(indType, obj.IndicatorTypes)
 		assert.Equal(kchain, obj.KillChainPhases)
 		assert.Equal(ts, obj.ValidUntil)
 		assert.Equal(patVer, obj.PatternVersion)
@@ -124,10 +126,9 @@ func TestIndicatorIndicates(t *testing.T) {
 	pattern := "new pattern"
 	patternType := "stix"
 	ts := &Timestamp{time.Now()}
-	indType := []string{IndicatorTypeCompromised}
 
 	t.Run("attack-pattern", func(t *testing.T) {
-		obj, err := NewIndicator(pattern, patternType, indType, ts)
+		obj, err := NewIndicator(pattern, patternType, ts)
 		assert.NoError(err)
 		id := NewIdentifier(TypeAttackPattern)
 		rel, err := obj.AddIndicates(id)
@@ -137,7 +138,7 @@ func TestIndicatorIndicates(t *testing.T) {
 	})
 
 	t.Run("campaign", func(t *testing.T) {
-		obj, err := NewIndicator(pattern, patternType, indType, ts)
+		obj, err := NewIndicator(pattern, patternType, ts)
 		assert.NoError(err)
 		id := NewIdentifier(TypeCampaign)
 		rel, err := obj.AddIndicates(id)
@@ -147,7 +148,7 @@ func TestIndicatorIndicates(t *testing.T) {
 	})
 
 	t.Run("infrastructure", func(t *testing.T) {
-		obj, err := NewIndicator(pattern, patternType, indType, ts)
+		obj, err := NewIndicator(pattern, patternType, ts)
 		assert.NoError(err)
 		id := NewIdentifier(TypeInfrastructure)
 		rel, err := obj.AddIndicates(id)
@@ -157,7 +158,7 @@ func TestIndicatorIndicates(t *testing.T) {
 	})
 
 	t.Run("intrusion-set", func(t *testing.T) {
-		obj, err := NewIndicator(pattern, patternType, indType, ts)
+		obj, err := NewIndicator(pattern, patternType, ts)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIntrusionSet)
 		rel, err := obj.AddIndicates(id)
@@ -167,7 +168,7 @@ func TestIndicatorIndicates(t *testing.T) {
 	})
 
 	t.Run("malware", func(t *testing.T) {
-		obj, err := NewIndicator(pattern, patternType, indType, ts)
+		obj, err := NewIndicator(pattern, patternType, ts)
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := obj.AddIndicates(id)
@@ -177,7 +178,7 @@ func TestIndicatorIndicates(t *testing.T) {
 	})
 
 	t.Run("threat-actor", func(t *testing.T) {
-		obj, err := NewIndicator(pattern, patternType, indType, ts)
+		obj, err := NewIndicator(pattern, patternType, ts)
 		assert.NoError(err)
 		id := NewIdentifier(TypeThreatActor)
 		rel, err := obj.AddIndicates(id)
@@ -187,7 +188,7 @@ func TestIndicatorIndicates(t *testing.T) {
 	})
 
 	t.Run("tool", func(t *testing.T) {
-		obj, err := NewIndicator(pattern, patternType, indType, ts)
+		obj, err := NewIndicator(pattern, patternType, ts)
 		assert.NoError(err)
 		id := NewIdentifier(TypeTool)
 		rel, err := obj.AddIndicates(id)
@@ -197,7 +198,7 @@ func TestIndicatorIndicates(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewIndicator(pattern, patternType, indType, ts)
+		obj, err := NewIndicator(pattern, patternType, ts)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddIndicates(id)
@@ -211,10 +212,9 @@ func TestIndicatorBasedOn(t *testing.T) {
 	pattern := "new pattern"
 	patternType := "stix"
 	ts := &Timestamp{time.Now()}
-	indType := []string{IndicatorTypeCompromised}
 
 	t.Run("observed-data", func(t *testing.T) {
-		obj, err := NewIndicator(pattern, patternType, indType, ts)
+		obj, err := NewIndicator(pattern, patternType, ts)
 		assert.NoError(err)
 		id := NewIdentifier(TypeObservedData)
 		rel, err := obj.AddBasedOn(id)
@@ -224,7 +224,7 @@ func TestIndicatorBasedOn(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewIndicator(pattern, patternType, indType, ts)
+		obj, err := NewIndicator(pattern, patternType, ts)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddBasedOn(id)

--- a/infrastructure.go
+++ b/infrastructure.go
@@ -115,12 +115,12 @@ func (c *Infrastructure) AddUses(id Identifier, opts ...RelationshipOption) (*Re
 }
 
 // NewInfrastructure creates a new Infrastructure object.
-func NewInfrastructure(name string, typs []string, opts ...InfrastructureOption) (*Infrastructure, error) {
-	if name == "" || len(typs) == 0 {
+func NewInfrastructure(name string, opts ...InfrastructureOption) (*Infrastructure, error) {
+	if name == "" {
 		return nil, ErrPropertyMissing
 	}
 	base := newSTIXDomainObject(TypeInfrastructure)
-	obj := &Infrastructure{STIXDomainObject: base, Name: name, InfrastructureTypes: typs}
+	obj := &Infrastructure{STIXDomainObject: base, Name: name}
 
 	for _, opt := range opts {
 		if opt == nil {
@@ -260,6 +260,13 @@ func InfrastructureOptionCreatedBy(id Identifier) InfrastructureOption {
 func InfrastructureOptionDescription(des string) InfrastructureOption {
 	return func(obj *Infrastructure) {
 		obj.Description = des
+	}
+}
+
+// InfrastructureOptionTypes sets the infrastructure types attribute.
+func InfrastructureOptionTypes(s []string) InfrastructureOption {
+	return func(obj *Infrastructure) {
+		obj.InfrastructureTypes = s
 	}
 }
 

--- a/infrastructure_test.go
+++ b/infrastructure_test.go
@@ -15,17 +15,15 @@ func TestInfrastructure(t *testing.T) {
 	assert := assert.New(t)
 
 	name := "new name"
-	// ts := &Timestamp{time.Now()}
-	typ := []string{InfrastructureTypeCommandAndControl}
 
 	t.Run("missing_property", func(t *testing.T) {
-		obj, err := NewInfrastructure("", []string{})
+		obj, err := NewInfrastructure("")
 		assert.Nil(obj)
 		assert.Equal(ErrPropertyMissing, err)
 	})
 
 	t.Run("no_optional", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typ, nil)
+		obj, err := NewInfrastructure(name, nil)
 		assert.NotNil(obj)
 		assert.NoError(err)
 	})
@@ -43,6 +41,7 @@ func TestInfrastructure(t *testing.T) {
 		specVer := "2.0"
 
 		kchain := []*KillChainPhase{{}}
+		typ := []string{InfrastructureTypeCommandAndControl}
 		aliases := []string{"1", "2"}
 
 		opts := []InfrastructureOption{
@@ -59,12 +58,13 @@ func TestInfrastructure(t *testing.T) {
 			InfrastructureOptionSpecVersion(specVer),
 			//
 			InfrastructureOptionDescription(desc),
+			InfrastructureOptionTypes(typ),
 			InfrastructureOptionKillChainPhase(kchain),
 			InfrastructureOptionAliases(aliases),
 			InfrastructureOptionFirstSeen(ts),
 			InfrastructureOptionLastSeen(ts),
 		}
-		obj, err := NewInfrastructure(name, typ, opts...)
+		obj, err := NewInfrastructure(name, opts...)
 		assert.NotNil(obj)
 		assert.NoError(err)
 		assert.Equal(conf, obj.Confidence)
@@ -81,6 +81,7 @@ func TestInfrastructure(t *testing.T) {
 		assert.Equal(name, obj.Name)
 
 		assert.Equal(desc, obj.Description)
+		assert.Equal(typ, obj.InfrastructureTypes)
 		assert.Equal(kchain, obj.KillChainPhases)
 		assert.Equal(ts, obj.FirstSeen)
 		assert.Equal(ts, obj.LastSeen)
@@ -115,10 +116,9 @@ func TestInfrastructure(t *testing.T) {
 func TestInfrastructureCommunicatesWith(t *testing.T) {
 	assert := assert.New(t)
 	name := "new name"
-	typs := []string{InfrastructureTypeCommandAndControl}
 
 	t.Run("infrastructure", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeInfrastructure)
 		rel, err := obj.AddCommunicatesWith(id)
@@ -129,7 +129,7 @@ func TestInfrastructureCommunicatesWith(t *testing.T) {
 	})
 
 	t.Run("ipv4", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddCommunicatesWith(id)
@@ -140,7 +140,7 @@ func TestInfrastructureCommunicatesWith(t *testing.T) {
 	})
 
 	t.Run("ipv6", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv6Addr)
 		rel, err := obj.AddCommunicatesWith(id)
@@ -151,7 +151,7 @@ func TestInfrastructureCommunicatesWith(t *testing.T) {
 	})
 
 	t.Run("domain-name", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeDomainName)
 		rel, err := obj.AddCommunicatesWith(id)
@@ -162,7 +162,7 @@ func TestInfrastructureCommunicatesWith(t *testing.T) {
 	})
 
 	t.Run("url", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeURL)
 		rel, err := obj.AddCommunicatesWith(id)
@@ -173,7 +173,7 @@ func TestInfrastructureCommunicatesWith(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeAttackPattern)
 		rel, err := obj.AddCommunicatesWith(id)
@@ -185,10 +185,9 @@ func TestInfrastructureCommunicatesWith(t *testing.T) {
 func TestInfrastructureConsistsOf(t *testing.T) {
 	assert := assert.New(t)
 	name := "new name"
-	typs := []string{InfrastructureTypeCommandAndControl}
 
 	t.Run("infrastructure", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeInfrastructure)
 		rel, err := obj.AddConsistsOf(id)
@@ -199,7 +198,7 @@ func TestInfrastructureConsistsOf(t *testing.T) {
 	})
 
 	t.Run("observed-data", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeObservedData)
 		rel, err := obj.AddConsistsOf(id)
@@ -210,7 +209,7 @@ func TestInfrastructureConsistsOf(t *testing.T) {
 	})
 
 	t.Run("invalid-identifier", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := Identifier("invalid")
 		rel, err := obj.AddConsistsOf(id)
@@ -222,10 +221,9 @@ func TestInfrastructureConsistsOf(t *testing.T) {
 func TestInfrastructureControls(t *testing.T) {
 	assert := assert.New(t)
 	name := "new name"
-	typs := []string{InfrastructureTypeCommandAndControl}
 
 	t.Run("infrastructure", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeInfrastructure)
 		rel, err := obj.AddControls(id)
@@ -236,7 +234,7 @@ func TestInfrastructureControls(t *testing.T) {
 	})
 
 	t.Run("malware", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := obj.AddControls(id)
@@ -247,7 +245,7 @@ func TestInfrastructureControls(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddControls(id)
@@ -259,10 +257,9 @@ func TestInfrastructureControls(t *testing.T) {
 func TestInfrastructureDelivers(t *testing.T) {
 	assert := assert.New(t)
 	name := "new name"
-	typs := []string{InfrastructureTypeCommandAndControl}
 
 	t.Run("malware", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := obj.AddDelivers(id)
@@ -273,7 +270,7 @@ func TestInfrastructureDelivers(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddDelivers(id)
@@ -285,10 +282,9 @@ func TestInfrastructureDelivers(t *testing.T) {
 func TestInfrastructureHas(t *testing.T) {
 	assert := assert.New(t)
 	name := "new name"
-	typs := []string{InfrastructureTypeCommandAndControl}
 
 	t.Run("vulnerability", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeVulnerability)
 		rel, err := obj.AddHas(id)
@@ -299,7 +295,7 @@ func TestInfrastructureHas(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddHas(id)
@@ -311,10 +307,9 @@ func TestInfrastructureHas(t *testing.T) {
 func TestInfrastructureHosts(t *testing.T) {
 	assert := assert.New(t)
 	name := "new name"
-	typs := []string{InfrastructureTypeCommandAndControl}
 
 	t.Run("tool", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeTool)
 		rel, err := obj.AddHosts(id)
@@ -325,7 +320,7 @@ func TestInfrastructureHosts(t *testing.T) {
 	})
 
 	t.Run("malware", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := obj.AddHosts(id)
@@ -336,7 +331,7 @@ func TestInfrastructureHosts(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddHosts(id)
@@ -348,10 +343,9 @@ func TestInfrastructureHosts(t *testing.T) {
 func TestInfrastructureLocatedAt(t *testing.T) {
 	assert := assert.New(t)
 	name := "new name"
-	typs := []string{InfrastructureTypeCommandAndControl}
 
 	t.Run("location", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeLocation)
 		rel, err := obj.AddLocatedAt(id)
@@ -362,7 +356,7 @@ func TestInfrastructureLocatedAt(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddLocatedAt(id)
@@ -374,10 +368,9 @@ func TestInfrastructureLocatedAt(t *testing.T) {
 func TestInfrastructureUses(t *testing.T) {
 	assert := assert.New(t)
 	name := "new name"
-	typs := []string{InfrastructureTypeCommandAndControl}
 
 	t.Run("infrastructure", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeInfrastructure)
 		rel, err := obj.AddUses(id)
@@ -388,7 +381,7 @@ func TestInfrastructureUses(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewInfrastructure(name, typs)
+		obj, err := NewInfrastructure(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddUses(id)

--- a/malware.go
+++ b/malware.go
@@ -53,12 +53,12 @@ type Malware struct {
 	// LastSeen is the time that the malware family or malware instance was
 	// last seen.
 	LastSeen *Timestamp `json:"last_seen,omitempty"`
-	// OS is the operating systems that the malware family or malware instance
-	// is executable on. Each string value for this property SHOULD be a CPE
-	// v2.3 entry from the official NVD CPE Dictionary. This property MAY
-	// include custom values including values taken from other standards such
-	// as SWID.
-	OS string `json:"os_execution_envs,omitempty"`
+	// OS is operating system the malware family or malware instance is
+	// executable on. This applies to virtualized operating systems as well
+	// as those running on bare metal.
+	//
+	// The value of this property MUST be the identifier for a SCO software object.
+	OS []Identifier `json:"operating_system_refs,omitempty"`
 	// Architecture is the processor architectures (e.g., x86, ARM, etc.) that
 	// the malware instance or family is executable on.
 	Architecture []string `json:"architecture_execution_envs,omitempty"`
@@ -203,14 +203,10 @@ func (c *Malware) AddVariantOf(id Identifier, opts ...RelationshipOption) (*Rela
 }
 
 // NewMalware creates a new Malware object.
-func NewMalware(malwareTypes []string, family bool, opts ...MalwareOption) (*Malware, error) {
-	if len(malwareTypes) == 0 {
-		return nil, ErrPropertyMissing
-	}
+func NewMalware(family bool, opts ...MalwareOption) (*Malware, error) {
 	base := newSTIXDomainObject(TypeMalware)
 	obj := &Malware{
 		STIXDomainObject: base,
-		MalwareType:      malwareTypes,
 		IsFamily:         family,
 	}
 
@@ -330,6 +326,13 @@ func MalwareOptionName(s string) MalwareOption {
 	}
 }
 
+// MalwareOptionTypes sets the malware types attribute.
+func MalwareOptionTypes(s []string) MalwareOption {
+	return func(obj *Malware) {
+		obj.MalwareType = s
+	}
+}
+
 // MalwareOptionAliases sets the aliases attribute.
 func MalwareOptionAliases(s []string) MalwareOption {
 	return func(obj *Malware) {
@@ -359,7 +362,7 @@ func MalwareOptionLastSeen(t *Timestamp) MalwareOption {
 }
 
 // MalwareOptionOS sets the OS attribute.
-func MalwareOptionOS(s string) MalwareOption {
+func MalwareOptionOS(s []Identifier) MalwareOption {
 	return func(obj *Malware) {
 		obj.OS = s
 	}

--- a/malware_test.go
+++ b/malware_test.go
@@ -14,16 +14,8 @@ import (
 func TestMalware(t *testing.T) {
 	assert := assert.New(t)
 
-	typs := []string{MalwareTypeBot}
-
-	t.Run("missing_property", func(t *testing.T) {
-		obj, err := NewMalware([]string{}, false)
-		assert.Nil(obj)
-		assert.Equal(ErrPropertyMissing, err)
-	})
-
 	t.Run("no_optional", func(t *testing.T) {
-		obj, err := NewMalware(typs, false, nil)
+		obj, err := NewMalware(false, nil)
 		assert.NotNil(obj)
 		assert.NoError(err)
 	})
@@ -41,9 +33,10 @@ func TestMalware(t *testing.T) {
 		specVer := "2.0"
 
 		name := "new name"
+		typs := []string{MalwareTypeBot}
 		aliases := []string{"Name 1", "Name 2"}
 		kcf := []*KillChainPhase{{}}
-		os := "windows"
+		os := []Identifier{NewObservableIdenfier("Windows", TypeSoftware)}
 		arch := []string{ArchitectureX8664}
 		langu := []string{ImplementationLanguageGo}
 		capa := []string{MalwareCapabilitiesCommunicatesWithC2}
@@ -64,6 +57,7 @@ func TestMalware(t *testing.T) {
 			//
 			MalwareOptionDescription(desc),
 			MalwareOptionName(name),
+			MalwareOptionTypes(typs),
 			MalwareOptionAliases(aliases),
 			MalwareOptionKillChainPhase(kcf),
 			MalwareOptionFirstSeen(ts),
@@ -74,7 +68,7 @@ func TestMalware(t *testing.T) {
 			MalwareOptionCapabilities(capa),
 			MalwareOptionSamples(samples),
 		}
-		obj, err := NewMalware(typs, true, opts...)
+		obj, err := NewMalware(true, opts...)
 		assert.NotNil(obj)
 		assert.NoError(err)
 		assert.Equal(conf, obj.Confidence)
@@ -91,6 +85,7 @@ func TestMalware(t *testing.T) {
 
 		assert.Equal(desc, obj.Description)
 		assert.Equal(name, obj.Name)
+		assert.Equal(typs, obj.MalwareType)
 		assert.Equal(aliases, obj.Aliases)
 		assert.Equal(kcf, obj.KillChainPhase)
 		assert.Equal(ts, obj.FirstSeen)
@@ -114,7 +109,7 @@ func TestMalware(t *testing.T) {
 			{true, "", ErrInvalidProperty},
 		}
 		for _, test := range tests {
-			_, err := NewMalware([]string{MalwareTypeBootkit}, test.fam, MalwareOptionName(test.nam))
+			_, err := NewMalware(test.fam, MalwareOptionName(test.nam))
 			assert.Equal(test.err, err)
 		}
 	})
@@ -150,10 +145,9 @@ func TestMalware(t *testing.T) {
 
 func TestMalwareAuthoredBy(t *testing.T) {
 	assert := assert.New(t)
-	typs := []string{MalwareTypeBackdoor}
 
 	t.Run("threat-actor", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeThreatActor)
 		rel, err := obj.AddAuthoredBy(id)
@@ -164,7 +158,7 @@ func TestMalwareAuthoredBy(t *testing.T) {
 	})
 
 	t.Run("intrusion-set", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIntrusionSet)
 		rel, err := obj.AddAuthoredBy(id)
@@ -175,7 +169,7 @@ func TestMalwareAuthoredBy(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddAuthoredBy(id)
@@ -186,10 +180,9 @@ func TestMalwareAuthoredBy(t *testing.T) {
 
 func TestMalwareBeaconsTo(t *testing.T) {
 	assert := assert.New(t)
-	typs := []string{MalwareTypeBackdoor}
 
 	t.Run("infrastructure", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeInfrastructure)
 		rel, err := obj.AddBeaconsTo(id)
@@ -200,7 +193,7 @@ func TestMalwareBeaconsTo(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddBeaconsTo(id)
@@ -211,10 +204,9 @@ func TestMalwareBeaconsTo(t *testing.T) {
 
 func TestMalwareExfiltratesTo(t *testing.T) {
 	assert := assert.New(t)
-	typs := []string{MalwareTypeBackdoor}
 
 	t.Run("infrastructure", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeInfrastructure)
 		rel, err := obj.AddExfiltratesTo(id)
@@ -225,7 +217,7 @@ func TestMalwareExfiltratesTo(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddExfiltratesTo(id)
@@ -236,10 +228,9 @@ func TestMalwareExfiltratesTo(t *testing.T) {
 
 func TestMalwareCommunicatesWith(t *testing.T) {
 	assert := assert.New(t)
-	typs := []string{MalwareTypeBackdoor}
 
 	t.Run("IPv4", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddCommunicatesWith(id)
@@ -250,7 +241,7 @@ func TestMalwareCommunicatesWith(t *testing.T) {
 	})
 
 	t.Run("IPv6", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv6Addr)
 		rel, err := obj.AddCommunicatesWith(id)
@@ -261,7 +252,7 @@ func TestMalwareCommunicatesWith(t *testing.T) {
 	})
 
 	t.Run("domain", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeDomainName)
 		rel, err := obj.AddCommunicatesWith(id)
@@ -272,7 +263,7 @@ func TestMalwareCommunicatesWith(t *testing.T) {
 	})
 
 	t.Run("URL", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeURL)
 		rel, err := obj.AddCommunicatesWith(id)
@@ -283,7 +274,7 @@ func TestMalwareCommunicatesWith(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := obj.AddCommunicatesWith(id)
@@ -294,10 +285,9 @@ func TestMalwareCommunicatesWith(t *testing.T) {
 
 func TestMalwareControls(t *testing.T) {
 	assert := assert.New(t)
-	typs := []string{MalwareTypeBackdoor}
 
 	t.Run("malware", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := obj.AddControls(id)
@@ -308,7 +298,7 @@ func TestMalwareControls(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddControls(id)
@@ -319,10 +309,9 @@ func TestMalwareControls(t *testing.T) {
 
 func TestMalwareDownloads(t *testing.T) {
 	assert := assert.New(t)
-	typs := []string{MalwareTypeBackdoor}
 
 	t.Run("malware", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := obj.AddDownloads(id)
@@ -333,7 +322,7 @@ func TestMalwareDownloads(t *testing.T) {
 	})
 
 	t.Run("tool", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeTool)
 		rel, err := obj.AddDownloads(id)
@@ -344,7 +333,7 @@ func TestMalwareDownloads(t *testing.T) {
 	})
 
 	t.Run("file", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeFile)
 		rel, err := obj.AddDownloads(id)
@@ -355,7 +344,7 @@ func TestMalwareDownloads(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddDownloads(id)
@@ -366,10 +355,9 @@ func TestMalwareDownloads(t *testing.T) {
 
 func TestMalwareDrops(t *testing.T) {
 	assert := assert.New(t)
-	typs := []string{MalwareTypeBackdoor}
 
 	t.Run("malware", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := obj.AddDrops(id)
@@ -380,7 +368,7 @@ func TestMalwareDrops(t *testing.T) {
 	})
 
 	t.Run("tool", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeTool)
 		rel, err := obj.AddDrops(id)
@@ -391,7 +379,7 @@ func TestMalwareDrops(t *testing.T) {
 	})
 
 	t.Run("file", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeFile)
 		rel, err := obj.AddDrops(id)
@@ -402,7 +390,7 @@ func TestMalwareDrops(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddDrops(id)
@@ -413,10 +401,9 @@ func TestMalwareDrops(t *testing.T) {
 
 func TestMalwareExploits(t *testing.T) {
 	assert := assert.New(t)
-	typs := []string{MalwareTypeBackdoor}
 
 	t.Run("vulnerability", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeVulnerability)
 		rel, err := obj.AddExploits(id)
@@ -427,7 +414,7 @@ func TestMalwareExploits(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddExploits(id)
@@ -438,10 +425,9 @@ func TestMalwareExploits(t *testing.T) {
 
 func TestMalwareOriginatesFrom(t *testing.T) {
 	assert := assert.New(t)
-	typs := []string{MalwareTypeBackdoor}
 
 	t.Run("location", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeLocation)
 		rel, err := obj.AddOriginatesFrom(id)
@@ -452,7 +438,7 @@ func TestMalwareOriginatesFrom(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddOriginatesFrom(id)
@@ -463,10 +449,9 @@ func TestMalwareOriginatesFrom(t *testing.T) {
 
 func TestMalwareTargets(t *testing.T) {
 	assert := assert.New(t)
-	typs := []string{MalwareTypeBackdoor}
 
 	t.Run("identity", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIdentity)
 		rel, err := obj.AddTargets(id)
@@ -477,7 +462,7 @@ func TestMalwareTargets(t *testing.T) {
 	})
 
 	t.Run("infrastructure", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeInfrastructure)
 		rel, err := obj.AddTargets(id)
@@ -488,7 +473,7 @@ func TestMalwareTargets(t *testing.T) {
 	})
 
 	t.Run("location", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeLocation)
 		rel, err := obj.AddTargets(id)
@@ -499,7 +484,7 @@ func TestMalwareTargets(t *testing.T) {
 	})
 
 	t.Run("vulnerability", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeVulnerability)
 		rel, err := obj.AddTargets(id)
@@ -510,7 +495,7 @@ func TestMalwareTargets(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddTargets(id)
@@ -521,10 +506,9 @@ func TestMalwareTargets(t *testing.T) {
 
 func TestMalwareUses(t *testing.T) {
 	assert := assert.New(t)
-	typs := []string{MalwareTypeBackdoor}
 
 	t.Run("attack-pattern", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeAttackPattern)
 		rel, err := obj.AddUses(id)
@@ -535,7 +519,7 @@ func TestMalwareUses(t *testing.T) {
 	})
 
 	t.Run("infrastructure", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeInfrastructure)
 		rel, err := obj.AddUses(id)
@@ -546,7 +530,7 @@ func TestMalwareUses(t *testing.T) {
 	})
 
 	t.Run("malware", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := obj.AddUses(id)
@@ -557,7 +541,7 @@ func TestMalwareUses(t *testing.T) {
 	})
 
 	t.Run("tool", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeTool)
 		rel, err := obj.AddUses(id)
@@ -568,7 +552,7 @@ func TestMalwareUses(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddUses(id)
@@ -579,10 +563,9 @@ func TestMalwareUses(t *testing.T) {
 
 func TestMalwareVariantOf(t *testing.T) {
 	assert := assert.New(t)
-	typs := []string{MalwareTypeBackdoor}
 
 	t.Run("malware", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := obj.AddVariantOf(id)
@@ -593,7 +576,7 @@ func TestMalwareVariantOf(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		obj, err := NewMalware(typs, false)
+		obj, err := NewMalware(false)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := obj.AddVariantOf(id)

--- a/report.go
+++ b/report.go
@@ -36,15 +36,14 @@ type Report struct {
 }
 
 // NewReport creates a new Report object.
-func NewReport(name string, reportType []string, published *Timestamp, objects []Identifier, opts ...ReportOption) (*Report, error) {
-	if name == "" || len(reportType) == 0 || published == nil || len(objects) == 0 {
+func NewReport(name string, published *Timestamp, objects []Identifier, opts ...ReportOption) (*Report, error) {
+	if name == "" || published == nil || len(objects) == 0 {
 		return nil, ErrPropertyMissing
 	}
 	base := newSTIXDomainObject(TypeReport)
 	obj := &Report{
 		STIXDomainObject: base,
 		Name:             name,
-		Types:            reportType,
 		Published:        published,
 		Objects:          objects,
 	}
@@ -151,6 +150,13 @@ func ReportOptionCreatedBy(id Identifier) ReportOption {
 func ReportOptionDescription(s string) ReportOption {
 	return func(obj *Report) {
 		obj.Description = s
+	}
+}
+
+// ReportOptionTypes sets the types attribute.
+func ReportOptionTypes(s []string) ReportOption {
+	return func(obj *Report) {
+		obj.Types = s
 	}
 }
 

--- a/report_test.go
+++ b/report_test.go
@@ -18,16 +18,15 @@ func TestReport(t *testing.T) {
 	desc := "Report content"
 	objects := []Identifier{Identifier("something")}
 	name := "Report name"
-	typs := []string{ReportTypeAttackPattern}
 
 	t.Run("missing_property", func(t *testing.T) {
-		obj, err := NewReport("", []string{}, nil, []Identifier{}, nil)
+		obj, err := NewReport("", nil, []Identifier{}, nil)
 		assert.Nil(obj)
 		assert.Equal(ErrPropertyMissing, err)
 	})
 
 	t.Run("no_optional", func(t *testing.T) {
-		obj, err := NewReport(name, typs, ts, objects, nil)
+		obj, err := NewReport(name, ts, objects, nil)
 		assert.NotNil(obj)
 		assert.NoError(err)
 	})
@@ -41,6 +40,8 @@ func TestReport(t *testing.T) {
 		lang := "en"
 		objmark := []Identifier{Identifier("id")}
 		specVer := "2.0"
+
+		typs := []string{ReportTypeAttackPattern}
 
 		opts := []ReportOption{
 			ReportOptionConfidence(conf),
@@ -56,8 +57,9 @@ func TestReport(t *testing.T) {
 			ReportOptionSpecVersion(specVer),
 			//
 			ReportOptionDescription(desc),
+			ReportOptionTypes(typs),
 		}
-		obj, err := NewReport(name, typs, ts, objects, opts...)
+		obj, err := NewReport(name, ts, objects, opts...)
 		assert.NotNil(obj)
 		assert.NoError(err)
 		assert.Equal(conf, obj.Confidence)

--- a/threat-actor.go
+++ b/threat-actor.go
@@ -149,15 +149,14 @@ func (a *ThreatActor) AddUses(id Identifier, opts ...RelationshipOption) (*Relat
 }
 
 // NewThreatActor creates a new ThreatActor object.
-func NewThreatActor(name string, types []string, opts ...ThreatActorOption) (*ThreatActor, error) {
-	if name == "" || len(types) == 0 {
+func NewThreatActor(name string, opts ...ThreatActorOption) (*ThreatActor, error) {
+	if name == "" {
 		return nil, ErrPropertyMissing
 	}
 	base := newSTIXDomainObject(TypeThreatActor)
 	obj := &ThreatActor{
 		STIXDomainObject: base,
 		Name:             name,
-		Types:            types,
 	}
 
 	for _, opt := range opts {
@@ -262,6 +261,13 @@ func ThreatActorOptionCreatedBy(id Identifier) ThreatActorOption {
 func ThreatActorOptionDescription(s string) ThreatActorOption {
 	return func(obj *ThreatActor) {
 		obj.Description = s
+	}
+}
+
+// ThreatActorOptionTypes sets the threat actor types attribute.
+func ThreatActorOptionTypes(s []string) ThreatActorOption {
+	return func(obj *ThreatActor) {
+		obj.Types = s
 	}
 }
 

--- a/threat-actor_test.go
+++ b/threat-actor_test.go
@@ -17,7 +17,6 @@ func TestThreatActor(t *testing.T) {
 	ts := &Timestamp{time.Now()}
 	desc := "ThreatActor content"
 	name := "ThreatActor name"
-	typs := []string{ThreatActorTypeCriminal}
 	alias := []string{"Name 1"}
 	roles := []string{ThreatActorRoleIndependent}
 	goals := []string{"money"}
@@ -28,13 +27,13 @@ func TestThreatActor(t *testing.T) {
 	pers := []string{AttackMotivationPersonalSatisfaction}
 
 	t.Run("missing_property", func(t *testing.T) {
-		obj, err := NewThreatActor("", []string{}, nil)
+		obj, err := NewThreatActor("", nil)
 		assert.Nil(obj)
 		assert.Equal(ErrPropertyMissing, err)
 	})
 
 	t.Run("no_optional", func(t *testing.T) {
-		obj, err := NewThreatActor(name, typs, nil)
+		obj, err := NewThreatActor(name, nil)
 		assert.NotNil(obj)
 		assert.NoError(err)
 	})
@@ -48,6 +47,8 @@ func TestThreatActor(t *testing.T) {
 		lang := "en"
 		objmark := []Identifier{Identifier("id")}
 		specVer := "2.0"
+
+		typs := []string{ThreatActorTypeCriminal}
 
 		opts := []ThreatActorOption{
 			ThreatActorOptionConfidence(conf),
@@ -63,6 +64,7 @@ func TestThreatActor(t *testing.T) {
 			ThreatActorOptionSpecVersion(specVer),
 			//
 			ThreatActorOptionDescription(desc),
+			ThreatActorOptionTypes(typs),
 			ThreatActorOptionAliases(alias),
 			ThreatActorOptionFirstSeen(ts),
 			ThreatActorOptionLastSeen(ts),
@@ -74,7 +76,7 @@ func TestThreatActor(t *testing.T) {
 			ThreatActorOptionSecondaryMotivations(secd),
 			ThreatActorOptionPersonalMotivations(pers),
 		}
-		obj, err := NewThreatActor(name, typs, opts...)
+		obj, err := NewThreatActor(name, opts...)
 		assert.NotNil(obj)
 		assert.NoError(err)
 		assert.Equal(conf, obj.Confidence)
@@ -142,10 +144,9 @@ func TestThreatActor(t *testing.T) {
 func TestThreatActorAttributedTo(t *testing.T) {
 	assert := assert.New(t)
 	name := "ThreatActor name"
-	typs := []string{ThreatActorTypeCriminal}
 
 	t.Run("identity", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIdentity)
 		rel, err := a.AddAttributedTo(id)
@@ -156,7 +157,7 @@ func TestThreatActorAttributedTo(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := a.AddAttributedTo(id)
@@ -168,10 +169,9 @@ func TestThreatActorAttributedTo(t *testing.T) {
 func TestThreatActorCompromises(t *testing.T) {
 	assert := assert.New(t)
 	name := "ThreatActor name"
-	typs := []string{ThreatActorTypeCriminal}
 
 	t.Run("Infrastructure", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeInfrastructure)
 		rel, err := a.AddCompromises(id)
@@ -182,7 +182,7 @@ func TestThreatActorCompromises(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := a.AddCompromises(id)
@@ -194,10 +194,9 @@ func TestThreatActorCompromises(t *testing.T) {
 func TestThreatActorHosts(t *testing.T) {
 	assert := assert.New(t)
 	name := "ThreatActor name"
-	typs := []string{ThreatActorTypeCriminal}
 
 	t.Run("Infrastructure", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeInfrastructure)
 		rel, err := a.AddHosts(id)
@@ -208,7 +207,7 @@ func TestThreatActorHosts(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := a.AddHosts(id)
@@ -220,10 +219,9 @@ func TestThreatActorHosts(t *testing.T) {
 func TestThreatActorOwns(t *testing.T) {
 	assert := assert.New(t)
 	name := "ThreatActor name"
-	typs := []string{ThreatActorTypeCriminal}
 
 	t.Run("Infrastructure", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeInfrastructure)
 		rel, err := a.AddOwns(id)
@@ -234,7 +232,7 @@ func TestThreatActorOwns(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := a.AddOwns(id)
@@ -246,10 +244,9 @@ func TestThreatActorOwns(t *testing.T) {
 func TestThreatActorImpersonates(t *testing.T) {
 	assert := assert.New(t)
 	name := "ThreatActor name"
-	typs := []string{ThreatActorTypeCriminal}
 
 	t.Run("identity", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIdentity)
 		rel, err := a.AddImpersonates(id)
@@ -260,7 +257,7 @@ func TestThreatActorImpersonates(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := a.AddImpersonates(id)
@@ -272,10 +269,9 @@ func TestThreatActorImpersonates(t *testing.T) {
 func TestThreatActorLocatedAt(t *testing.T) {
 	assert := assert.New(t)
 	name := "ThreatActor name"
-	typs := []string{ThreatActorTypeCriminal}
 
 	t.Run("location", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeLocation)
 		rel, err := a.AddLocatedAt(id)
@@ -286,7 +282,7 @@ func TestThreatActorLocatedAt(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := a.AddLocatedAt(id)
@@ -298,10 +294,9 @@ func TestThreatActorLocatedAt(t *testing.T) {
 func TestThreatActorTargets(t *testing.T) {
 	assert := assert.New(t)
 	name := "ThreatActor name"
-	typs := []string{ThreatActorTypeCriminal}
 
 	t.Run("identity", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIdentity)
 		rel, err := a.AddTargets(id)
@@ -312,7 +307,7 @@ func TestThreatActorTargets(t *testing.T) {
 	})
 
 	t.Run("location", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeLocation)
 		rel, err := a.AddTargets(id)
@@ -323,7 +318,7 @@ func TestThreatActorTargets(t *testing.T) {
 	})
 
 	t.Run("vulnerability", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeVulnerability)
 		rel, err := a.AddTargets(id)
@@ -334,7 +329,7 @@ func TestThreatActorTargets(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := a.AddTargets(id)
@@ -346,10 +341,9 @@ func TestThreatActorTargets(t *testing.T) {
 func TestThreatActorUses(t *testing.T) {
 	assert := assert.New(t)
 	name := "ThreatActor name"
-	typs := []string{ThreatActorTypeCriminal}
 
 	t.Run("attack-pattern", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeAttackPattern)
 		rel, err := a.AddUses(id)
@@ -360,7 +354,7 @@ func TestThreatActorUses(t *testing.T) {
 	})
 
 	t.Run("Infrastructure", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeInfrastructure)
 		rel, err := a.AddUses(id)
@@ -371,7 +365,7 @@ func TestThreatActorUses(t *testing.T) {
 	})
 
 	t.Run("malware", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := a.AddUses(id)
@@ -382,7 +376,7 @@ func TestThreatActorUses(t *testing.T) {
 	})
 
 	t.Run("tool", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeTool)
 		rel, err := a.AddUses(id)
@@ -393,7 +387,7 @@ func TestThreatActorUses(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		a, err := NewThreatActor(name, typs)
+		a, err := NewThreatActor(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := a.AddUses(id)

--- a/tool.go
+++ b/tool.go
@@ -86,15 +86,14 @@ func (a *Tool) AddUses(id Identifier, opts ...RelationshipOption) (*Relationship
 }
 
 // NewTool creates a new Tool object.
-func NewTool(name string, types []string, opts ...ToolOption) (*Tool, error) {
-	if name == "" || len(types) == 0 {
+func NewTool(name string, opts ...ToolOption) (*Tool, error) {
+	if name == "" {
 		return nil, ErrPropertyMissing
 	}
 	base := newSTIXDomainObject(TypeTool)
 	obj := &Tool{
 		STIXDomainObject: base,
 		Name:             name,
-		Types:            types,
 	}
 
 	for _, opt := range opts {
@@ -199,6 +198,13 @@ func ToolOptionCreatedBy(id Identifier) ToolOption {
 func ToolOptionDescription(s string) ToolOption {
 	return func(obj *Tool) {
 		obj.Description = s
+	}
+}
+
+// ToolOptionTypes sets the tool types attribute.
+func ToolOptionTypes(s []string) ToolOption {
+	return func(obj *Tool) {
+		obj.Types = s
 	}
 }
 

--- a/tool_test.go
+++ b/tool_test.go
@@ -23,13 +23,13 @@ func TestTool(t *testing.T) {
 	toolVersion := "1.0"
 
 	t.Run("missing_property", func(t *testing.T) {
-		obj, err := NewTool("", []string{}, nil)
+		obj, err := NewTool("", nil)
 		assert.Nil(obj)
 		assert.Equal(ErrPropertyMissing, err)
 	})
 
 	t.Run("no_optional", func(t *testing.T) {
-		obj, err := NewTool(name, typs, nil)
+		obj, err := NewTool(name, nil)
 		assert.NotNil(obj)
 		assert.NoError(err)
 	})
@@ -58,11 +58,12 @@ func TestTool(t *testing.T) {
 			ToolOptionSpecVersion(specVer),
 			//
 			ToolOptionDescription(desc),
+			ToolOptionTypes(typs),
 			ToolOptionAliases(alias),
 			ToolOptionKillChainPhase(kcf),
 			ToolOptionToolVersion(toolVersion),
 		}
-		obj, err := NewTool(name, typs, opts...)
+		obj, err := NewTool(name, opts...)
 		assert.NotNil(obj)
 		assert.NoError(err)
 		assert.Equal(conf, obj.Confidence)
@@ -114,10 +115,9 @@ func TestTool(t *testing.T) {
 func TestToolDelivers(t *testing.T) {
 	assert := assert.New(t)
 	name := "Tool name"
-	typs := []string{ToolTypeExploitation}
 
 	t.Run("malware", func(t *testing.T) {
-		a, err := NewTool(name, typs)
+		a, err := NewTool(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := a.AddDelivers(id)
@@ -128,7 +128,7 @@ func TestToolDelivers(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		a, err := NewTool(name, typs)
+		a, err := NewTool(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := a.AddDelivers(id)
@@ -140,10 +140,9 @@ func TestToolDelivers(t *testing.T) {
 func TestToolDrops(t *testing.T) {
 	assert := assert.New(t)
 	name := "Tool name"
-	typs := []string{ToolTypeDenialOfService}
 
 	t.Run("Infrastructure", func(t *testing.T) {
-		a, err := NewTool(name, typs)
+		a, err := NewTool(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeMalware)
 		rel, err := a.AddDrops(id)
@@ -154,7 +153,7 @@ func TestToolDrops(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		a, err := NewTool(name, typs)
+		a, err := NewTool(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := a.AddDrops(id)
@@ -166,10 +165,9 @@ func TestToolDrops(t *testing.T) {
 func TestToolHas(t *testing.T) {
 	assert := assert.New(t)
 	name := "Tool name"
-	typs := []string{ToolTypeNetworkCapture}
 
 	t.Run("Infrastructure", func(t *testing.T) {
-		a, err := NewTool(name, typs)
+		a, err := NewTool(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeVulnerability)
 		rel, err := a.AddHas(id)
@@ -180,7 +178,7 @@ func TestToolHas(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		a, err := NewTool(name, typs)
+		a, err := NewTool(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := a.AddHas(id)
@@ -192,10 +190,9 @@ func TestToolHas(t *testing.T) {
 func TestToolTargets(t *testing.T) {
 	assert := assert.New(t)
 	name := "Tool name"
-	typs := []string{ToolTypeVulnerabilityScanning}
 
 	t.Run("identity", func(t *testing.T) {
-		a, err := NewTool(name, typs)
+		a, err := NewTool(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIdentity)
 		rel, err := a.AddTargets(id)
@@ -206,7 +203,7 @@ func TestToolTargets(t *testing.T) {
 	})
 
 	t.Run("Infrastructure", func(t *testing.T) {
-		a, err := NewTool(name, typs)
+		a, err := NewTool(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeInfrastructure)
 		rel, err := a.AddTargets(id)
@@ -217,7 +214,7 @@ func TestToolTargets(t *testing.T) {
 	})
 
 	t.Run("location", func(t *testing.T) {
-		a, err := NewTool(name, typs)
+		a, err := NewTool(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeLocation)
 		rel, err := a.AddTargets(id)
@@ -228,7 +225,7 @@ func TestToolTargets(t *testing.T) {
 	})
 
 	t.Run("vulnerability", func(t *testing.T) {
-		a, err := NewTool(name, typs)
+		a, err := NewTool(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeVulnerability)
 		rel, err := a.AddTargets(id)
@@ -239,7 +236,7 @@ func TestToolTargets(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		a, err := NewTool(name, typs)
+		a, err := NewTool(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := a.AddTargets(id)
@@ -251,10 +248,9 @@ func TestToolTargets(t *testing.T) {
 func TestToolUses(t *testing.T) {
 	assert := assert.New(t)
 	name := "Tool name"
-	typs := []string{ToolTypeInformationGathering}
 
 	t.Run("Infrastructure", func(t *testing.T) {
-		a, err := NewTool(name, typs)
+		a, err := NewTool(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeInfrastructure)
 		rel, err := a.AddUses(id)
@@ -265,7 +261,7 @@ func TestToolUses(t *testing.T) {
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
-		a, err := NewTool(name, typs)
+		a, err := NewTool(name)
 		assert.NoError(err)
 		id := NewIdentifier(TypeIPv4Addr)
 		rel, err := a.AddUses(id)


### PR DESCRIPTION
Addressing things reported in issue #27.

Changes:
- identity_class changed to optional
- indicator_types changed to optional
- infrastructure_types changed to optional
- malware_types changed to optional
- os_execution_envs changed to operating_system_refs
- report_types changed to optional
- threat_actor_types change to optional
- tool_types changed to optional
- parent_directory_ref added to file hash contribution