### PR TITLE
Add options to Collection object

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ method on the Collection object. The Bundle can be serialized to `JSON`
 using the `JSON` encoder in the standard library.
 
 ```go
-c := &stix2.Collection{}
+c := stix2.New()
 ip, err := stix2.NewIPv4Address("10.0.0.1")
 c.Add(ip)
 ip, err = stix2.NewIPv4Address("10.0.0.2")
@@ -41,7 +41,7 @@ data, err := json.Marshal(b)
 Taken from: https://docs.oasis-open.org/cti/stix/v2.1/csprd02/stix-v2.1-csprd02.html#_Toc26789941
 
 ```go
-collection := &stix2.Collection{}
+collection := stix2.New()
 domain, err := stix2.NewDomainName("example.com")
 collection.Add(domain)
 

--- a/doc.go
+++ b/doc.go
@@ -14,7 +14,7 @@ them to the Collection. The Bundle can be created by calling the `ToBundle`
 method on the Collection object. The Bundle can be serialized to `JSON`
 using the `JSON` encoder in the standard library.
 
-	c := &stix2.Collection{}
+	c := stix2.New()
 	ip, err := stix2.NewIPv4Address("10.0.0.1")
 	c.Add(ip)
 	ip, err = stix2.NewIPv4Address("10.0.0.2")
@@ -25,7 +25,7 @@ using the `JSON` encoder in the standard library.
 Example of a malware using an infrastructure. Taken from:
 https://docs.oasis-open.org/cti/stix/v2.1/csprd02/stix-v2.1-csprd02.html#_Toc26789941
 
-	collection := &stix2.Collection{}
+	collection := stix2.New()
 	domain, err := stix2.NewDomainName("example.com")
 	collection.Add(domain)
 

--- a/example_test.go
+++ b/example_test.go
@@ -74,7 +74,7 @@ func ExampleFromJSON() {
 }
 
 func ExampleCollection_ToBundle() {
-	c := &stix2.Collection{}
+	c := stix2.New()
 	ip, err := stix2.NewIPv4Address("10.0.0.1")
 	if err != nil {
 		fmt.Println(err)
@@ -101,7 +101,7 @@ func ExampleCollection_ToBundle() {
 
 func Example() {
 	// Taken from: https://docs.oasis-open.org/cti/stix/v2.1/csprd02/stix-v2.1-csprd02.html#_Toc26789941
-	collection := &stix2.Collection{}
+	collection := stix2.New()
 	domain, err := stix2.NewDomainName("example.com")
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
Collection can now be created via the "New" function. The function takes arguments that allows for controlling some of the collection's behavior.

By default a Collection tracks the order of items added so outputs are predictable. This can be disabled via an option parameter.