### PR TITLE
Extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,12 @@ b, err := collection.ToBundle()
 data, err := json.MarshalIndent(b, "", "\t")
 ```
 
-## To-do
+## Extensions and Customization
 
-- [x] Provide a solution to create a bundle from the collection object.
-- [ ] Add more data validations when creating objects
-- [ ] Support and documentation for customization
-- [ ] Ensure SITX 2.0 is supported
+With the release of version 2.1 of the specification custom properties
+has been deprecated. Instead, `property-extension` functionality should
+be used. This library supports parsing objects with old custom properties
+for backwards compatibility. The fields can be accessed via the 
+`GetExtendedTopLevelProperties` method.
 
+See the examples in the documentation on how to work with extensions.

--- a/artifact.go
+++ b/artifact.go
@@ -36,6 +36,10 @@ type Artifact struct {
 	Key string `json:"decryption_key,omitempty"`
 }
 
+func (o *Artifact) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewArtifact creates a new Artifact object.
 func NewArtifact(opts ...STIXOption) (*Artifact, error) {
 	base := newSTIXCyberObservableObject(TypeArtifact)

--- a/artifact.go
+++ b/artifact.go
@@ -65,7 +65,7 @@ func NewArtifact(opts ...STIXOption) (*Artifact, error) {
 	if len(obj.Payload) != 0 {
 		contriStr = append(contriStr, `"`+obj.Payload.String()+`"`)
 	}
-	obj.ID = NewObservableIdenfier("["+strings.Join(contriStr, ",")+"]", TypeArtifact)
+	obj.ID = NewObservableIdentifier("["+strings.Join(contriStr, ",")+"]", TypeArtifact)
 	return obj, nil
 }
 

--- a/artifact_test.go
+++ b/artifact_test.go
@@ -53,7 +53,6 @@ func TestArtifact(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 			//
 			OptionMimeType(mime),
 			OptionPayload(payload),

--- a/as.go
+++ b/as.go
@@ -18,6 +18,10 @@ type AutonomousSystem struct {
 	RIR string `json:"rir,omitempty"`
 }
 
+func (o *AutonomousSystem) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewAutonomousSystem creates a new AutonomousSystem object.
 func NewAutonomousSystem(number int64, opts ...STIXOption) (*AutonomousSystem, error) {
 	if number == 0 {

--- a/as.go
+++ b/as.go
@@ -30,6 +30,6 @@ func NewAutonomousSystem(number int64, opts ...STIXOption) (*AutonomousSystem, e
 	}
 
 	err := applyOptions(obj, opts)
-	obj.ID = NewObservableIdenfier(fmt.Sprintf("[%d]", number), TypeAutonomousSystem)
+	obj.ID = NewObservableIdentifier(fmt.Sprintf("[%d]", number), TypeAutonomousSystem)
 	return obj, err
 }

--- a/as_test.go
+++ b/as_test.go
@@ -39,7 +39,6 @@ func TestAS(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 			//
 			OptionName(name),
 			OptionRIR(rir),

--- a/attack.go
+++ b/attack.go
@@ -29,6 +29,10 @@ type AttackPattern struct {
 	KillChainPhase []*KillChainPhase `json:"kill_chain_phases,omitempty"`
 }
 
+func (o *AttackPattern) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // AddDelivers creates a relationship to a malware delivered by this object.
 func (a *AttackPattern) AddDelivers(id Identifier, opts ...STIXOption) (*Relationship, error) {
 	if !IsValidIdentifier(id) || !id.ForType(TypeMalware) {

--- a/bundle_test.go
+++ b/bundle_test.go
@@ -57,5 +57,5 @@ func TestCreateBundle(t *testing.T) {
 
 	data, err := json.Marshal(b)
 	assert.NoError(err)
-	assert.Contains(string(data), `"type":"ipv4-addr","id":"ipv4-addr--8e9dc7c8-b845-5cfb-9c37-cff3a18e08d6","spec_version":"2.1","value":"10.0.0.1"`)
+	assert.Contains(string(data), `"id":"ipv4-addr--8e9dc7c8-b845-5cfb-9c37-cff3a18e08d6","spec_version":"2.1","type":"ipv4-addr","value":"10.0.0.1"`)
 }

--- a/campaign.go
+++ b/campaign.go
@@ -38,6 +38,10 @@ type Campaign struct {
 	Objective string `json:"objective,omitempty"`
 }
 
+func (o *Campaign) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // AddTargets creates a relationship to either an identity, location, or
 // vulnerability that is targeted by this campaign.
 func (c *Campaign) AddTargets(id Identifier, opts ...STIXOption) (*Relationship, error) {

--- a/course-of-action.go
+++ b/course-of-action.go
@@ -22,6 +22,10 @@ type CourseOfAction struct {
 	Description string `json:"description,omitempty"`
 }
 
+func (o *CourseOfAction) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // AddInvestigates creates an investigate relationship between the course of
 // action and an indicator.
 func (c *CourseOfAction) AddInvestigates(id Identifier, opts ...STIXOption) (*Relationship, error) {

--- a/crash_test.go
+++ b/crash_test.go
@@ -13,7 +13,7 @@ import (
 func TestCrashCollectionAdd(t *testing.T) {
 	runFolderTest(t, "crashesCollectionAdd", func(a *assert.Assertions, testData []byte) {
 		a.NotPanics(func() {
-			col, err := stix2.FromJSON(testData)
+			col, err := stix2.FromJSON(testData, stix2.DropCustomOption())
 			a.Error(err)
 			a.Nil(col)
 		})

--- a/data-types.go
+++ b/data-types.go
@@ -258,6 +258,8 @@ const (
 	TypeEmailMIME STIXType = "mime-part-type"
 	// TypeEmailMessage is used for email message type.
 	TypeEmailMessage STIXType = "email-message"
+	// TypeExtensionDefinition is used for extension definition type.
+	TypeExtensionDefinition STIXType = "extension-definition"
 	// TypeFile is used for file types.
 	TypeFile STIXType = "file"
 	// TypeGrouping is used for grouping type.

--- a/data-types.go
+++ b/data-types.go
@@ -25,24 +25,15 @@ func (typ Binary) String() string {
 
 // UnmarshalJSON extracts the binary data from the json data.
 func (typ *Binary) UnmarshalJSON(b []byte) error {
-	if len(b) < 2 {
-		return nil
-	}
-	t := string(b[1 : len(b)-1])
-	data, err := base64.StdEncoding.DecodeString(t)
-	if err != nil {
-		return err
-	}
-	*typ = data
-	return nil
+	var buf []byte
+	err := json.Unmarshal(b, &buf)
+	*typ = Binary(buf)
+	return err
 }
 
 // MarshalJSON converts the binary data to base64 for JSON serialization.
 func (typ Binary) MarshalJSON() ([]byte, error) {
-	if len(typ) < 1 {
-		return []byte{}, nil
-	}
-	return []byte("\"" + typ.String() + "\""), nil
+	return json.Marshal([]byte(typ))
 }
 
 // Hex type encodes an array of octets (8-bit bytes) as hexadecimal. The string
@@ -452,9 +443,6 @@ func (t *Timestamp) MarshalJSON() ([]byte, error) {
 func (t *Timestamp) UnmarshalJSON(b []byte) error {
 	// Removing the two " and parse the timestamp.
 	stamp, err := time.Parse(time.RFC3339Nano, string(b[1:len(b)-1]))
-	if err != nil {
-		return err
-	}
 	*t = Timestamp{stamp}
-	return nil
+	return err
 }

--- a/data-types.go
+++ b/data-types.go
@@ -212,8 +212,8 @@ func NewIdentifier(typ STIXType) Identifier {
 	return Identifier(fmt.Sprintf("%s--%s", typ, id))
 }
 
-// NewObservableIdenfier creates a new STIX Cyber-observable Object identifier.
-func NewObservableIdenfier(value string, typ STIXType) Identifier {
+// NewObservableIdentifier creates a new STIX Cyber-observable Object identifier.
+func NewObservableIdentifier(value string, typ STIXType) Identifier {
 	id := uuid.NewSHA1(CyberObservableNamespace, []byte(value))
 	return Identifier(fmt.Sprintf("%s--%s", typ, id))
 }

--- a/data-types.go
+++ b/data-types.go
@@ -336,6 +336,7 @@ var AllTypes = []STIXType{
 	TypeEmailAddress,
 	TypeEmailMIME,
 	TypeEmailMessage,
+	TypeExtensionDefinition,
 	TypeFile,
 	TypeGrouping,
 	TypeIPv4Addr,

--- a/data-types_test.go
+++ b/data-types_test.go
@@ -164,7 +164,7 @@ func TestIdentifier(t *testing.T) {
 	})
 
 	t.Run("NewObservableID", func(t *testing.T) {
-		id := NewObservableIdenfier("198.51.100.3", TypeIPv4Addr)
+		id := NewObservableIdentifier("198.51.100.3", TypeIPv4Addr)
 		assert.Equal(Identifier("ipv4-addr--0ec1740c-3e52-5d42-8659-da680987dff8"), id)
 	})
 }

--- a/directory.go
+++ b/directory.go
@@ -31,6 +31,10 @@ type Directory struct {
 	Contains []Identifier `json:"contains_refs,omitempty"`
 }
 
+func (o *Directory) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewDirectory creates a new Directory object.
 func NewDirectory(path string, opts ...STIXOption) (*Directory, error) {
 	if path == "" {

--- a/directory.go
+++ b/directory.go
@@ -43,6 +43,6 @@ func NewDirectory(path string, opts ...STIXOption) (*Directory, error) {
 	}
 
 	err := applyOptions(obj, opts)
-	obj.ID = NewObservableIdenfier(fmt.Sprintf("[\"%s\"]", path), TypeDirectory)
+	obj.ID = NewObservableIdentifier(fmt.Sprintf("[\"%s\"]", path), TypeDirectory)
 	return obj, err
 }

--- a/directory_test.go
+++ b/directory_test.go
@@ -41,7 +41,6 @@ func TestDirectory(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 			//
 			OptionPathEncoding(pthEnc),
 			OptionCtime(ts),

--- a/dns.go
+++ b/dns.go
@@ -40,6 +40,6 @@ func NewDomainName(value string, opts ...STIXOption) (*DomainName, error) {
 	}
 
 	err := applyOptions(obj, opts)
-	obj.ID = NewObservableIdenfier(fmt.Sprintf("[\"%s\"]", value), TypeDomainName)
+	obj.ID = NewObservableIdentifier(fmt.Sprintf("[\"%s\"]", value), TypeDomainName)
 	return obj, err
 }

--- a/dns.go
+++ b/dns.go
@@ -19,6 +19,10 @@ type DomainName struct {
 	ResolvesTo []Identifier `json:"resolves_to_refs,omitempty"`
 }
 
+func (o *DomainName) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // AddResolvesTo describes that this Domain Name resolves to one or more IP
 // addresses or domain names.
 func (c *DomainName) AddResolvesTo(id Identifier, opts ...STIXOption) (*Relationship, error) {

--- a/dns_test.go
+++ b/dns_test.go
@@ -38,7 +38,6 @@ func TestDomain(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 			OptionResolvesTo([]Identifier{resolve}),
 		}
 		obj, err := NewDomainName(name, opts...)

--- a/doc.go
+++ b/doc.go
@@ -50,5 +50,15 @@ https://docs.oasis-open.org/cti/stix/v2.1/csprd02/stix-v2.1-csprd02.html#_Toc267
 
 	b, err := collection.ToBundle()
 	data, err := json.MarshalIndent(b, "", "\t")
+
+Extensions and Customization
+
+With the release of version 2.1 of the specification custom properties
+has been deprecated. Instead, `property-extension` functionality should
+be used. This library supports parsing objects with old custom properties
+for backwards compatibility. The fields can be accessed via the
+`GetExtendedTopLevelProperties` method.
+
+See the examples on how to work with extensions.
 */
 package stix2

--- a/email.go
+++ b/email.go
@@ -22,6 +22,10 @@ type EmailAddress struct {
 	BelongsTo Identifier `json:"belongs_to_ref,omitempty"`
 }
 
+func (o *EmailAddress) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewEmailAddress creates a new EmailAddress object.
 func NewEmailAddress(value string, opts ...STIXOption) (*EmailAddress, error) {
 	if value == "" {
@@ -97,6 +101,10 @@ type EmailMessage struct {
 	// including both the headers and body, as a reference to an Artifact
 	// object.
 	RawEmail Identifier `json:"raw_email_ref,omitempty"`
+}
+
+func (o *EmailMessage) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
 }
 
 // NewEmailMessage creates a new EmailMessage object.

--- a/email.go
+++ b/email.go
@@ -34,7 +34,7 @@ func NewEmailAddress(value string, opts ...STIXOption) (*EmailAddress, error) {
 	}
 
 	err := applyOptions(obj, opts)
-	obj.ID = NewObservableIdenfier(fmt.Sprintf("[\"%s\"]", value), TypeEmailAddress)
+	obj.ID = NewObservableIdentifier(fmt.Sprintf("[\"%s\"]", value), TypeEmailAddress)
 	return obj, err
 }
 
@@ -118,7 +118,7 @@ func NewEmailMessage(multipart bool, opts ...STIXOption) (*EmailMessage, error) 
 	if obj.Body != "" {
 		idContri = append(idContri, fmt.Sprintf(`"%s"`, obj.Body))
 	}
-	obj.ID = NewObservableIdenfier(fmt.Sprintf("[%s]", strings.Join(idContri, ",")), TypeEmailMessage)
+	obj.ID = NewObservableIdentifier(fmt.Sprintf("[%s]", strings.Join(idContri, ",")), TypeEmailMessage)
 	return obj, err
 }
 

--- a/email_test.go
+++ b/email_test.go
@@ -40,7 +40,7 @@ func TestEmailAddress(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
+			// OptionExtension("test", struct{}{}),
 			//
 			OptionDisplayName(name),
 			OptionBelongsTo(belong),
@@ -116,7 +116,6 @@ func TestEmailMessage(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 			//
 			OptionDate(ts),
 			OptionContentType(msg),

--- a/example_test.go
+++ b/example_test.go
@@ -150,3 +150,92 @@ func Example() {
 	}
 	fmt.Println(string(data))
 }
+
+func ExampleCustomObject() {
+	// Define the custom fields
+	ext := &stix2.CustomObject{}
+	ext.Set("some_new_property", "a string value")
+
+	// The extension definition.
+	ed, _ := stix2.NewExtensionDefinition(
+		"A custom extension",
+		"https://example.com/v1/schema",
+		"1.0",
+		[]stix2.ExtensionType{stix2.ExtensionTypePropertyExtension},
+	)
+
+	// Create a DomainName object with the additional field.
+	d, _ := stix2.NewDomainName("example.com", stix2.OptionExtension(string(ed.ID), ext))
+
+	fmt.Println(d.Extensions[string(ed.ID)].(*stix2.CustomObject).GetAsString("some_new_property"))
+
+	//Output:
+	// a string value
+}
+
+func ExampleCustomObject_attack() {
+	data := []byte(`[{
+		"id": "attack-pattern--3fc9b85a-2862-4363-a64d-d692e3ffbee0",
+		"description": "Adversaries may search for common password storage locations to obtain user credentials. Passwords are stored in several places on a system, depending on the operating system or application holding the credentials. There are also specific applications that store passwords to make it easier for users manage and maintain. Once credentials are obtained, they can be used to perform lateral movement and access restricted information.",
+		"name": "Credentials from Password Stores",
+		"created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+		"object_marking_refs": [
+			"marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168"
+		],
+		"external_references": [
+			{
+				"source_name": "mitre-attack",
+				"external_id": "T1555",
+				"url": "https://attack.mitre.org/techniques/T1555"
+			}
+		],
+		"type": "attack-pattern",
+		"kill_chain_phases": [
+			{
+				"kill_chain_name": "mitre-attack",
+				"phase_name": "credential-access"
+			}
+		],
+		"modified": "2021-04-29T21:00:19.428Z",
+		"created": "2020-02-11T18:48:28.456Z",
+		"x_mitre_platforms": [
+			"Linux",
+			"macOS",
+			"Windows"
+		],
+		"x_mitre_is_subtechnique": false,
+		"x_mitre_version": "1.0",
+		"x_mitre_detection": "Monitor system calls, file read events, and processes for suspicious activity that could indicate searching for a password  or other activity related to performing keyword searches (e.g. password, pwd, login, store, secure, credentials, etc.) in process memory for credentials. File read events should be monitored surrounding known password storage applications.",
+		"x_mitre_permissions_required": [
+			"Administrator"
+		],
+		"x_mitre_data_sources": [
+			"Process: Process Creation",
+			"File: File Access",
+			"Command: Command Execution",
+			"Process: OS API Execution",
+			"Process: Process Access"
+		],
+		"spec_version": "2.1",
+		"x_mitre_domains": [
+			"enterprise-attack"
+		],
+		"x_mitre_modified_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5"
+}]`)
+
+	col, err := stix2.FromJSON(data)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	obj := col.AttackPattern(stix2.Identifier("attack-pattern--3fc9b85a-2862-4363-a64d-d692e3ffbee0"))
+	fmt.Println(obj.Name)
+
+	// Get the custom properties.
+	ext := obj.GetExtendedTopLevelProperties()
+	fmt.Println(ext.GetAsString("x_mitre_version"))
+
+	//Output:
+	// Credentials from Password Stores
+	// 1.0
+}

--- a/extension.go
+++ b/extension.go
@@ -267,3 +267,90 @@ var encExtTypeMap = map[ExtensionType]string{
 	ExtensionTypePropertyExtension:         "property-extension",
 	ExtensionTypeToplevelPropertyExtension: "toplevel-property-extension",
 }
+
+// CustomObject is a custom STIX object that allows for extending the specification
+// by creating a new type.
+type CustomObject map[string]interface{}
+
+// Get retrives an attribute from the custom object.
+func (c CustomObject) Get(key string) interface{} {
+	val, ok := c[key]
+	if !ok {
+		return nil
+	}
+	return val
+}
+
+// Set adds an attribute to the custom object.
+func (c CustomObject) Set(key string, val interface{}) {
+	c[key] = val
+}
+
+// GetAsString returns the requested attribute as a string.
+func (c CustomObject) GetAsString(key string) string {
+	s := c.Get(key)
+	if s == nil {
+		return ""
+	}
+	return s.(string)
+}
+
+// GetAsStringSlice returns the requested attribute as a string slice.
+func (c CustomObject) GetAsStringSlice(key string) []string {
+	s := c.Get(key)
+	if s == nil {
+		return nil
+	}
+	return s.([]string)
+}
+
+// GetAsNumber returns the requested attribute as a number.
+func (c CustomObject) GetAsNumber(key string) int64 {
+	s := c.Get(key)
+	if s == nil {
+		return int64(0)
+	}
+	return s.(int64)
+}
+
+// GetID returns the identifier for the object.
+func (c CustomObject) GetID() Identifier {
+	val, ok := c["id"]
+	if !ok {
+		return Identifier("")
+	}
+	return Identifier(val.(string))
+}
+
+// GetType returns the object's type.
+func (c CustomObject) GetType() STIXType {
+	val, ok := c["type"]
+	if !ok {
+		return STIXType("")
+	}
+	return STIXType(val.(string))
+}
+
+// GetCreated returns the created time for the STIX object. If the object
+// does not have a time defined, nil is returned.
+func (c CustomObject) GetCreated() *time.Time {
+	return convTimeString(c, "created")
+}
+
+// GetModified returns the modified time for the STIX object. If the object
+// does not have a time defined, nil is returned.
+func (c CustomObject) GetModified() *time.Time {
+	return convTimeString(c, "modified")
+}
+
+func convTimeString(c CustomObject, key string) *time.Time {
+	ts, ok := c[key]
+	if !ok {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, ts.(string))
+	if err != nil {
+		return nil
+	}
+	return &t
+}

--- a/extension.go
+++ b/extension.go
@@ -1,3 +1,6 @@
+// Copyright 2021 Joakim Kennedy. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
 package stix2
 
 import (

--- a/extension.go
+++ b/extension.go
@@ -213,6 +213,12 @@ func (e *ExtensionDefinition) GetModified() *time.Time {
 	return &e.Modified.Time
 }
 
+// GetExtendedTopLevelProperties returns the extra top level properties or
+// nil for the object.
+func (s *ExtensionDefinition) GetExtendedTopLevelProperties() *CustomObject {
+	return nil
+}
+
 // ExtensionType describes what type of extension it is.
 type ExtensionType uint8
 
@@ -360,4 +366,10 @@ func convTimeString(c CustomObject, key string) *time.Time {
 		return nil
 	}
 	return &t
+}
+
+// GetExtendedTopLevelProperties returns the extra top level properties or
+// nil for the object.
+func (s *CustomObject) GetExtendedTopLevelProperties() *CustomObject {
+	return nil
 }

--- a/extension.go
+++ b/extension.go
@@ -1,0 +1,210 @@
+package stix2
+
+import "encoding/json"
+
+type Extensions map[string]interface{}
+
+func (o *Extensions) UnmarshalJSON(b []byte) error {
+	tmp := map[string]json.RawMessage{}
+
+	err := json.Unmarshal(b, &tmp)
+	if err != nil {
+		return err
+	}
+
+	final := make(map[string]interface{})
+
+	// Parse the extensions.
+	for k, v := range tmp {
+		var ext interface{}
+		switch k {
+		case ExtArchive:
+			ext = &ArchiveFileExtension{}
+		case ExtHTTPRequest:
+			ext = &HTTPRequestExtension{}
+		case ExtICMP:
+			ext = &ICMPExtension{}
+		case ExtNTFS:
+			ext = &NTFSFileExtension{}
+		case ExtPDF:
+			ext = &PDFExtension{}
+		case ExtRasterImage:
+			ext = &RasterImageExtension{}
+		case ExtSocket:
+			ext = &SocketExtension{}
+		case ExtTCP:
+			ext = &TCPExtension{}
+		case ExtUnixAccount:
+			ext = &UNIXAccountExtension{}
+		case ExtWindowsPEBinary:
+			ext = &WindowsPEBinaryExtension{}
+		case ExtWindowsProcess:
+			ext = &WindowsProcessExtension{}
+		case ExtWindowsService:
+			ext = &WindowsServiceExtension{}
+		default:
+			ext = &map[string]interface{}{}
+		}
+
+		err = json.Unmarshal(v, ext)
+		if err != nil {
+			return err
+		}
+		final[k] = ext
+	}
+
+	// Set the value.
+	*o = final
+	return nil
+}
+
+type ExtensionDefinition struct {
+	// The type property identifies the type of STIX Object. The value of the
+	// type property MUST be the name of one of the types of STIX Objects
+	Type STIXType `json:"type"`
+	// The id property uniquely identifies this object. For objects that
+	// support versioning, all objects with the same id are considered
+	// different versions of the same object and the version of the object is
+	// identified by its modified property.
+	ID Identifier `json:"id"`
+	// The version of the STIX specification used to represent this object.
+	SpecVersion string `json:"spec_version"`
+	// The created_by_ref property specifies the id property of the identity
+	// object that describes the entity that created this object. If this
+	// attribute is omitted, the source of this information is undefined. This
+	// may be used by object creators who wish to remain anonymous.
+	CreatedBy Identifier `json:"created_by_ref"`
+	// The created property represents the time at which the object was
+	// originally created. The object creator can use the time it deems most
+	// appropriate as the time the object was created, but it MUST be precise
+	// to the nearest millisecond (exactly three digits after the decimal place
+	// in seconds). The created property MUST NOT be changed when creating a
+	// new version of the object.
+	Created *Timestamp `json:"created"`
+	// The modified property is only used by STIX Objects that support
+	// versioning and represents the time that this particular version of the
+	// object was last modified. The object creator can use the time it deems
+	// most appropriate as the time this version of the object was modified,
+	// but it must be precise to the nearest millisecond (exactly three digits
+	// after the decimal place in seconds). If the created property is defined,
+	// then the value of the modified property for a given object version MUST
+	// be later than or equal to the value of the created property. Object
+	// creators MUST set the modified property when creating a new version of
+	// an object if the created property was set.
+	Modified *Timestamp `json:"modified"`
+	// The revoked property is only used by STIX Objects that support
+	// versioning and indicates whether the object has been revoked. Revoked
+	// objects are no longer considered valid by the object creator. Revoking
+	// an object is permanent; future versions of the object with this id MUST
+	// NOT be created.
+	Revoked bool `json:"revoked,omitempty"`
+	// The labels property specifies a set of terms used to describe this
+	// object. The terms are user-defined or trust-group defined and their
+	// meaning is outside the scope of this specification and MAY be ignored.
+	// Where an object has a specific property defined in the specification for
+	// characterizing subtypes of that object, the labels property MUST NOT be
+	// used for that purpose. For example, the Malware SDO has a property
+	// malware_types that contains a list of Malware subtypes (dropper, RAT,
+	// etc.). In this example, the labels property cannot be used to describe
+	// these Malware subtypes.
+	Labels []string `json:"labels,omitempty"`
+	// The ExternalReferences property specifies a list of external references
+	// which refers to non-STIX information. This property is used to provide
+	// one or more URLs, descriptions, or IDs to records in other systems.
+	ExternalReferences []*ExternalReference `json:"external_references,omitempty"`
+	// The object_marking_refs property specifies a list of id properties of
+	// marking-definition objects that apply to this object. In some cases,
+	// though uncommon, marking definitions themselves may be marked with
+	// sharing or handling guidance. In this case, this property MUST NOT
+	// contain any references to the same Marking Definition object (i.e., it
+	// cannot contain any circular references).
+	ObjectMarking []Identifier `json:"object_marking_refs,omitempty"`
+	// The granular_markings property specifies a list of granular markings
+	// applied to this object. In some cases, though uncommon, marking
+	// definitions themselves may be marked with sharing or handling guidance.
+	// In this case, this property MUST NOT contain any references to the same
+	// Marking Definition object (i.e., it cannot contain any circular
+	// references).
+	GranularMarking []*GranularMarking `json:"granular_markings,omitempty"`
+	// Name used for display purposes during execution, development, or debugging.
+	Name string `json:"name"`
+	// Description is a detailed explanation of what data the extension conveys and
+	// how it is intended to be used.
+	// While the description property is optional this property SHOULD be populated.
+	// Note that the schema property is the normative definition of the extension,
+	// and this property, if present, is for documentation purposes only.
+	Description string `json:"description,omitempty"`
+	// Schema is the normative definition of the extension, either as a URL or as
+	// plain text explaining the definition.
+	// A URL SHOULD point to a JSON schema or a location that contains information
+	// about the schema.
+	// NOTE: It is recommended that an external reference be provided to the
+	// comprehensive documentation of the extension-definition.
+	Schema string `json:"schema"`
+	// Version of this extension. Producers of STIX extensions are encouraged to
+	// follow standard semantic versioning procedures where the version number
+	// follows the pattern, MAJOR.MINOR.PATCH. This will allow consumers to
+	// distinguish between the three different levels of compatibility typically
+	// identified by such versioning strings.
+	Version string `json:"version"`
+	// ExtensionTypes property specifies one or more extension types contained
+	// within this extension.
+	// When this property includes toplevel-property- extension then the
+	// extension_properties property SHOULD include one or more property names.
+	ExtensionTypes []ExtensionType `json:"extension_types"`
+	// ExtensionProperties contains the list of new property names that are added
+	// to an object by an extension.
+	// This property MUST only be used when the extension_types property includes
+	// a value of toplevel- property-extension. In other words, when new properties
+	// are being added at the top-level of an existing object.
+	ExtensionProperties []string `json:"extension_properties,omitempty"`
+}
+
+// ExtensionType describes what type of extension it is.
+type ExtensionType uint8
+
+// String returns the string representation of the type.
+func (typ ExtensionType) String() string {
+	return encExtTypeMap[typ]
+}
+
+// UnmarshalJSON extracts the encryption algorithm from the json data.
+func (typ *ExtensionType) UnmarshalJSON(b []byte) error {
+	t := string(b[1 : len(b)-1])
+	for k, v := range encExtTypeMap {
+		if v == t {
+			*typ = k
+			return nil
+		}
+	}
+	*typ = ExtensionTypeInvalid
+	return nil
+}
+
+const (
+	// ExtensionTypeInvalid indicates that the extension type used is invalid.
+	ExtensionTypeInvalid ExtensionType = iota
+	// ExtensionTypeNewSDO specifies that the Extension includes a new SDO.
+	ExtensionTypeNewSDO
+	// ExtensionTypeNewSCO specifies that the Extension includes a new SCO.
+	ExtensionTypeNewSCO
+	// ExtensionTypeNewSRO specifies that the Extension includes a new SDO.
+	ExtensionTypeNewSRO
+	// ExtensionTypePropertyExtension specifies that the extension includes
+	// additional properties for a given STIX object.
+	ExtensionTypePropertyExtension
+	// ExtensionTypeToplevelPropertyExtension specifies that the Extension includes
+	// additional properties for a given STIX Object at the top-level.
+	// Organizations are encouraged to use the property-extension instead of
+	// this extension type.
+	ExtensionTypeToplevelPropertyExtension
+)
+
+var encExtTypeMap = map[ExtensionType]string{
+	ExtensionTypeInvalid:                   "",
+	ExtensionTypeNewSDO:                    "new-sdo",
+	ExtensionTypeNewSCO:                    "new-sco",
+	ExtensionTypeNewSRO:                    "new-sro",
+	ExtensionTypePropertyExtension:         "property-extension",
+	ExtensionTypeToplevelPropertyExtension: "toplevel-property-extension",
+}

--- a/extension.go
+++ b/extension.go
@@ -46,7 +46,7 @@ func (o *Extensions) UnmarshalJSON(b []byte) error {
 		case ExtWindowsService:
 			ext = &WindowsServiceExtension{}
 		default:
-			ext = &map[string]interface{}{}
+			ext = &CustomObject{}
 		}
 
 		err = json.Unmarshal(v, ext)
@@ -305,12 +305,19 @@ func (c CustomObject) GetAsStringSlice(key string) []string {
 }
 
 // GetAsNumber returns the requested attribute as a number.
+// The value has to be an expected integer.
 func (c CustomObject) GetAsNumber(key string) int64 {
 	s := c.Get(key)
 	if s == nil {
 		return int64(0)
 	}
-	return s.(int64)
+
+	if i, ok := s.(int64); ok {
+		return i
+	}
+
+	// The JSON unmarshal converts JSON numbers to float64
+	return int64(s.(float64))
 }
 
 // GetID returns the identifier for the object.

--- a/extension_test.go
+++ b/extension_test.go
@@ -234,6 +234,24 @@ func TestExtensionCustomObject(t *testing.T) {
 		assert.Nil(obj)
 		assert.Len(c.ExtensionDefinitions(), 1)
 	})
+
+	t.Run("existing-STIX-object-with-extra-properties", func(t *testing.T) {
+		data := []byte(fmt.Sprintf("[%s,%s]", extPropJson, sdoWithExtensionAttributes))
+		c, err := FromJSON(data)
+		assert.NoError(err)
+		assert.NotNil(c)
+
+		ind := c.Indicator(Identifier("indicator--e97bfccf-8970-4a3c-9cd1-5b5b97ed5d0c"))
+		assert.NotNil(ind)
+		e, ok := ind.Extensions["extension-definition--d83fce45-ef58-4c6c-a3f4-1fbc32e98c6e"]
+		assert.True(ok)
+		assert.NotNil(e)
+
+		ext := e.(*CustomObject)
+		assert.Equal(int64(5), ext.GetAsNumber("rank"))
+		assert.Equal(int64(8), ext.GetAsNumber("toxicity"))
+		assert.Equal("property-extension", ext.GetAsString("extension_type"))
+	})
 }
 
 const extPropJson = `{
@@ -262,6 +280,27 @@ const customObject = `{
 	"extensions": {
 	  "extension-definition--9c59fd79-4215-4ba2-920d-3e4f320e1e62": {
 		"extension_type": "new-sdo"
+	  }
+	}
+  }`
+
+const sdoWithExtensionAttributes = `{
+	"type": "indicator",
+	"spec_version": "2.1",
+	"id": "indicator--e97bfccf-8970-4a3c-9cd1-5b5b97ed5d0c",
+	"created": "2014-02-20T09:16:08.989000Z",
+	"modified": "2014-02-20T09:16:08.989000Z",
+	"name": "File hash for Poison Ivy variant",
+	"description": "This file hash indicates that a sample of Poison Ivy is present.",
+	"labels": ["malicious-activity"],
+	"pattern": "[file:hashes.'SHA-256' = 'ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c']",
+	"pattern_type": "stix",
+	"valid_from": "2014-02-20T09:00:00.000000Z",
+	"extensions": {
+	  "extension-definition--d83fce45-ef58-4c6c-a3f4-1fbc32e98c6e": {
+		"extension_type": "property-extension",
+		"rank": 5,
+		"toxicity": 8
 	  }
 	}
   }`

--- a/extension_test.go
+++ b/extension_test.go
@@ -218,6 +218,15 @@ func TestExtensionCustomObject(t *testing.T) {
 		assert.NotNil(custom.GetCreated())
 		assert.NotNil(custom.GetModified())
 	})
+
+	t.Run("allow-ignoring-custom-objects", func(t *testing.T) {
+		c, err := FromJSON(data, DropCustomOption())
+		assert.NoError(err)
+
+		obj := c.Get(Identifier("my-favorite-sdo--ac97aae4-83f1-46ca-a351-7aeb76678189"))
+		assert.Nil(obj)
+		assert.Len(c.ExtensionDefinitions(), 1)
+	})
 }
 
 const extPropJson = `{

--- a/extension_test.go
+++ b/extension_test.go
@@ -51,3 +51,115 @@ func TestExtensionJSONParsing(t *testing.T) {
 		assert.Error(err)
 	})
 }
+
+func TestExtensionProperties(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("require-parameters", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			schema  string
+			version string
+			types   []ExtensionType
+		}{
+			{"", "https://www.example.com/schema-my-favorite-sdo-1/v1/", "1.2.1", []ExtensionType{ExtensionTypeNewSDO}},
+			{"New SDO 1", "", "1.2.1", []ExtensionType{ExtensionTypeNewSDO}},
+			{"New SDO 1", "https://www.example.com/schema-my-favorite-sdo-1/v1/", "", []ExtensionType{ExtensionTypeNewSDO}},
+			{"New SDO 1", "https://www.example.com/schema-my-favorite-sdo-1/v1/", "1.2.1", []ExtensionType{}},
+		}
+		for _, test := range tests {
+			o, err := NewExtensionDefinition(test.name, test.schema, test.version, test.types)
+			assert.Nil(o)
+			assert.Equal(ErrInvalidParameter, err)
+		}
+	})
+
+	t.Run("create", func(t *testing.T) {
+		o, err := NewExtensionDefinition(
+			"New SDO 1",
+			"https://www.example.com/schema-my-favorite-sdo-1/v1/",
+			"1.2.1",
+			[]ExtensionType{ExtensionTypeNewSDO},
+			OptionExtensionProperties([]string{"some-prop"}),
+		)
+		assert.NoError(err)
+		assert.NotNil(o)
+		assert.Contains(o.ExtensionProperties, "some-prop")
+		assert.Equal(TypeExtensionDefinition, o.GetType())
+		assert.NotNil(o.GetID())
+		assert.NotNil(o.GetCreated())
+		assert.NotNil(o.GetModified())
+	})
+
+	t.Run("json-parsing", func(t *testing.T) {
+		var obj ExtensionDefinition
+		err := json.Unmarshal([]byte(extPropJson), &obj)
+		assert.NoError(err)
+		assert.NotNil(obj)
+		assert.Contains(obj.ExtensionTypes, ExtensionTypeNewSDO)
+	})
+}
+
+func TestExtensionType(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("parse-invalid", func(t *testing.T) {
+		invalid := []byte(`{
+			"id": "extension-definition--9c59fd79-4215-4ba2-920d-3e4f320e1e62",
+			"type": "extension-definition",
+			"spec_version": "2.1",
+			"name": "New SDO 1",
+			"description": "This schema creates a new object type called my-favorite-sdo-1",
+			"created": "2014-02-20T09:16:08.989000Z",
+			"modified": "2014-02-20T09:16:08.989000Z",
+			"created_by_ref": "identity--11b76a96-5d2b-45e0-8a5a-f6994f370731",
+			"schema": "https://www.example.com/schema-my-favorite-sdo-1/v1/",
+			"version": "1.2.1",
+			"extension_types": ["invalid-type"]
+		  }
+`)
+		var obj ExtensionDefinition
+		err := json.Unmarshal(invalid, &obj)
+		assert.NoError(err)
+		assert.Equal(ExtensionTypeInvalid, obj.ExtensionTypes[0])
+	})
+
+	t.Run("invalid-type-format", func(t *testing.T) {
+		invalid := []byte(`{
+			"id": "extension-definition--9c59fd79-4215-4ba2-920d-3e4f320e1e62",
+			"type": "extension-definition",
+			"spec_version": "2.1",
+			"name": "New SDO 1",
+			"description": "This schema creates a new object type called my-favorite-sdo-1",
+			"created": "2014-02-20T09:16:08.989000Z",
+			"modified": "2014-02-20T09:16:08.989000Z",
+			"created_by_ref": "identity--11b76a96-5d2b-45e0-8a5a-f6994f370731",
+			"schema": "https://www.example.com/schema-my-favorite-sdo-1/v1/",
+			"version": "1.2.1",
+			"extension_types": [1]
+		  }
+`)
+		var obj ExtensionDefinition
+		err := json.Unmarshal(invalid, &obj)
+		assert.Error(err)
+	})
+
+	t.Run("Stringer", func(t *testing.T) {
+		assert.Equal("new-sco", ExtensionTypeNewSCO.String())
+	})
+}
+
+const extPropJson = `{
+	"id": "extension-definition--9c59fd79-4215-4ba2-920d-3e4f320e1e62",
+	"type": "extension-definition",
+	"spec_version": "2.1",
+	"name": "New SDO 1",
+	"description": "This schema creates a new object type called my-favorite-sdo-1",
+	"created": "2014-02-20T09:16:08.989000Z",
+	"modified": "2014-02-20T09:16:08.989000Z",
+	"created_by_ref": "identity--11b76a96-5d2b-45e0-8a5a-f6994f370731",
+	"schema": "https://www.example.com/schema-my-favorite-sdo-1/v1/",
+	"version": "1.2.1",
+	"extension_types": ["new-sdo"]
+  }
+`

--- a/extension_test.go
+++ b/extension_test.go
@@ -346,6 +346,106 @@ func TestExtensionTopLevelProperties(t *testing.T) {
 		assert.Equal(int64(5), ext.GetAsNumber("rank"))
 		assert.Equal(int64(8), ext.GetAsNumber("toxicity"))
 	})
+
+	t.Run("sco-marshal-to-JSON", func(t *testing.T) {
+		c, err := FromJSON(data)
+		assert.NoError(err)
+		assert.NotNil(c)
+
+		objects := c.URLs()
+
+		c2 := New()
+		for _, o := range objects {
+			c2.Add(o)
+		}
+
+		b, err := c2.ToBundle()
+		assert.NoError(err)
+
+		buf, err := json.Marshal(b)
+		assert.NoError(err)
+		assert.Contains(string(buf), `"toxicity":8`)
+	})
+
+	t.Run("sdo-marshal-to-JSON", func(t *testing.T) {
+		c, err := FromJSON(data)
+		assert.NoError(err)
+		assert.NotNil(c)
+
+		objects := c.Indicators()
+
+		c2 := New()
+		for _, o := range objects {
+			c2.Add(o)
+		}
+
+		b, err := c2.ToBundle()
+		assert.NoError(err)
+
+		buf, err := json.Marshal(b)
+		assert.NoError(err)
+		assert.Contains(string(buf), `"toxicity":8`)
+	})
+
+	t.Run("sro-marshal-to-JSON", func(t *testing.T) {
+		c, err := FromJSON(data)
+		assert.NoError(err)
+		assert.NotNil(c)
+
+		objects := c.Sightings()
+
+		c2 := New()
+		for _, o := range objects {
+			c2.Add(o)
+		}
+
+		b, err := c2.ToBundle()
+		assert.NoError(err)
+
+		buf, err := json.Marshal(b)
+		assert.NoError(err)
+		assert.Contains(string(buf), `"toxicity":8`)
+	})
+
+	t.Run("language-marshal-to-JSON", func(t *testing.T) {
+		c, err := FromJSON(data)
+		assert.NoError(err)
+		assert.NotNil(c)
+
+		objects := c.LanguageContents()
+
+		c2 := New()
+		for _, o := range objects {
+			c2.Add(o)
+		}
+
+		b, err := c2.ToBundle()
+		assert.NoError(err)
+
+		buf, err := json.Marshal(b)
+		assert.NoError(err)
+		assert.Contains(string(buf), `"toxicity":8`)
+	})
+
+	t.Run("markings-marshal-to-JSON", func(t *testing.T) {
+		c, err := FromJSON(data)
+		assert.NoError(err)
+		assert.NotNil(c)
+
+		objects := c.MarkingDefinitions()
+
+		c2 := New()
+		for _, o := range objects {
+			c2.Add(o)
+		}
+
+		b, err := c2.ToBundle()
+		assert.NoError(err)
+
+		buf, err := json.Marshal(b)
+		assert.NoError(err)
+		assert.Contains(string(buf), `"toxicity":8`)
+	})
 }
 
 const extPropJson = `{

--- a/extension_test.go
+++ b/extension_test.go
@@ -1,3 +1,5 @@
+// Copyright 2021 Joakim Kennedy. All rights reserved. Use of
+// this source code is governed by the included BSD license.
 package stix2
 
 import (

--- a/extension_test.go
+++ b/extension_test.go
@@ -149,6 +149,40 @@ func TestExtensionType(t *testing.T) {
 	})
 }
 
+func TestSetExtensionsOption(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("SDO", func(t *testing.T) {
+		obj, err := NewAttackPattern("Some name", OptionExtension("extension-definition--9c59fd79-4215-4ba2-920d-3e4f320e1e62", extPropJson))
+		assert.NoError(err)
+		assert.NotNil(obj)
+	})
+
+	t.Run("SCO", func(t *testing.T) {
+		obj, err := NewDomainName("example.com", OptionExtension("extension-definition--9c59fd79-4215-4ba2-920d-3e4f320e1e62", extPropJson))
+		assert.NoError(err)
+		assert.NotNil(obj)
+	})
+
+	t.Run("SRO", func(t *testing.T) {
+		obj, err := NewRelationship(RelationshipTypeBasedOn, NewIdentifier(TypeArtifact), NewIdentifier(TypeFile), OptionExtension("extension-definition--9c59fd79-4215-4ba2-920d-3e4f320e1e62", extPropJson))
+		assert.NoError(err)
+		assert.NotNil(obj)
+	})
+
+	t.Run("Language", func(t *testing.T) {
+		obj, err := NewLanguageContent(NewIdentifier(TypeArtifact), make(map[string]map[string]interface{}), OptionExtension("extension-definition--9c59fd79-4215-4ba2-920d-3e4f320e1e62", extPropJson))
+		assert.NoError(err)
+		assert.NotNil(obj)
+	})
+
+	t.Run("Markings", func(t *testing.T) {
+		obj, err := NewMarkingDefinition("some new marking", "something", OptionExtension("extension-definition--9c59fd79-4215-4ba2-920d-3e4f320e1e62", extPropJson))
+		assert.NoError(err)
+		assert.NotNil(obj)
+	})
+}
+
 const extPropJson = `{
 	"id": "extension-definition--9c59fd79-4215-4ba2-920d-3e4f320e1e62",
 	"type": "extension-definition",

--- a/extension_test.go
+++ b/extension_test.go
@@ -89,6 +89,7 @@ func TestExtensionProperties(t *testing.T) {
 		assert.NotNil(o.GetID())
 		assert.NotNil(o.GetCreated())
 		assert.NotNil(o.GetModified())
+		assert.Nil(o.GetExtendedTopLevelProperties())
 	})
 
 	t.Run("json-parsing", func(t *testing.T) {
@@ -252,6 +253,99 @@ func TestExtensionCustomObject(t *testing.T) {
 		assert.Equal(int64(8), ext.GetAsNumber("toxicity"))
 		assert.Equal("property-extension", ext.GetAsString("extension_type"))
 	})
+
+	t.Run("check-some-attributes", func(t *testing.T) {
+		obj := &CustomObject{}
+		assert.Equal(Identifier(""), obj.GetID(), "should return empty string if not set")
+		assert.Nil(obj.GetExtendedTopLevelProperties(), "should always return nil")
+	})
+}
+
+func TestExtensionTopLevelProperties(t *testing.T) {
+	assert := assert.New(t)
+	data := []byte(fmt.Sprintf("[%s,%s,%s,%s,%s,%s]",
+		extPropJson,
+		sdoWithTopLevelAttributes,
+		markingsWithTopLevelAttributes,
+		languageWithTopLevelAttributes,
+		scoWithTopLevelAttributes,
+		sroWithTopLevelAttributes,
+	))
+
+	t.Run("parse-sdo-from-json", func(t *testing.T) {
+		c, err := FromJSON(data)
+		assert.NoError(err)
+		assert.NotNil(c)
+
+		obj := c.Indicator(Identifier("indicator--e97bfccf-8970-4a3c-9cd1-5b5b97ed5d0d"))
+		assert.NotNil(obj)
+
+		ext := obj.GetExtendedTopLevelProperties()
+		assert.NotNil(ext)
+
+		assert.Equal(int64(5), ext.GetAsNumber("rank"))
+		assert.Equal(int64(8), ext.GetAsNumber("toxicity"))
+	})
+
+	t.Run("parse-sco-from-json", func(t *testing.T) {
+		c, err := FromJSON(data)
+		assert.NoError(err)
+		assert.NotNil(c)
+
+		obj := c.URL(Identifier("url--c1477287-23ac-5971-a010-5c287877fa60"))
+		assert.NotNil(obj)
+
+		ext := obj.GetExtendedTopLevelProperties()
+		assert.NotNil(ext)
+
+		assert.Equal(int64(5), ext.GetAsNumber("rank"))
+		assert.Equal(int64(8), ext.GetAsNumber("toxicity"))
+	})
+
+	t.Run("parse-sro-from-json", func(t *testing.T) {
+		c, err := FromJSON(data)
+		assert.NoError(err)
+		assert.NotNil(c)
+
+		obj := c.Sighting(Identifier("sighting--ee20065d-2555-424f-ad9e-0f8428623c75"))
+		assert.NotNil(obj)
+
+		ext := obj.GetExtendedTopLevelProperties()
+		assert.NotNil(ext)
+
+		assert.Equal(int64(5), ext.GetAsNumber("rank"))
+		assert.Equal(int64(8), ext.GetAsNumber("toxicity"))
+	})
+
+	t.Run("parse-marking-from-json", func(t *testing.T) {
+		c, err := FromJSON(data)
+		assert.NoError(err)
+		assert.NotNil(c)
+
+		obj := c.MarkingDefinition(Identifier("marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da"))
+		assert.NotNil(obj)
+
+		ext := obj.GetExtendedTopLevelProperties()
+		assert.NotNil(ext)
+
+		assert.Equal(int64(5), ext.GetAsNumber("rank"))
+		assert.Equal(int64(8), ext.GetAsNumber("toxicity"))
+	})
+
+	t.Run("parse-language-from-json", func(t *testing.T) {
+		c, err := FromJSON(data)
+		assert.NoError(err)
+		assert.NotNil(c)
+
+		obj := c.LanguageContent(Identifier("language-content--b86bd89f-98bb-4fa9-8cb2-9ad421da981d"))
+		assert.NotNil(obj)
+
+		ext := obj.GetExtendedTopLevelProperties()
+		assert.NotNil(ext)
+
+		assert.Equal(int64(5), ext.GetAsNumber("rank"))
+		assert.Equal(int64(8), ext.GetAsNumber("toxicity"))
+	})
 }
 
 const extPropJson = `{
@@ -304,3 +398,107 @@ const sdoWithExtensionAttributes = `{
 	  }
 	}
   }`
+
+const sdoWithTopLevelAttributes = `{
+	"type": "indicator",
+	"spec_version": "2.1",
+	"id": "indicator--e97bfccf-8970-4a3c-9cd1-5b5b97ed5d0d",
+	"created": "2014-02-20T09:16:08.989000Z",
+	"modified": "2014-02-20T09:16:08.989000Z",
+	"name": "File hash for Poison Ivy variant",
+	"description": "This file hash indicates that a sample of Poison Ivy is present.",
+	"labels": ["malicious-activity"],
+	"pattern": "[file:hashes.'SHA-256' = 'ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c']",
+	"pattern_type": "stix",
+	"valid_from": "2014-02-20T09:00:00.000000Z",
+	"rank": 5,
+	"toxicity": 8,
+	"extensions": {
+	  "extension-definition--d83fce45-ef58-4c6c-a3f4-1fbc32e98c6e": {
+		"extension_type": "toplevel-property-extension"
+	  }
+	}
+}`
+
+const markingsWithTopLevelAttributes = `{
+    "type": "marking-definition",
+    "spec_version": "2.1",
+    "id": "marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da",
+    "created": "2016-08-01T00:00:00.000Z",
+    "definition_type": "statement",
+    "definition": {
+      "statement": "Copyright 2019, Example Corp"
+    },
+	"rank": 5,
+	"toxicity": 8,
+	"extensions": {
+	  "extension-definition--d83fce45-ef58-4c6c-a3f4-1fbc32e98c6e": {
+		"extension_type": "toplevel-property-extension"
+	  }
+	}
+}`
+
+const languageWithTopLevelAttributes = `{
+    "type": "language-content",
+    "id": "language-content--b86bd89f-98bb-4fa9-8cb2-9ad421da981d",
+    "spec_version": "2.1",
+    "created": "2017-02-08T21:31:22.007Z",
+    "modified": "2017-02-08T21:31:22.007Z",
+    "object_ref": "campaign--12a111f0-b824-4baf-a224-83b80237a094",
+    "object_modified": "2017-02-08T21:31:22.007Z",
+    "contents": {
+      "de": {
+        "name": "Bank Angriff",
+        "description": "Weitere Informationen über Banküberfall"
+      },
+      "fr": {
+        "name": "Attaque Bank",
+        "description": "Plus d'informations sur la crise bancaire"
+      }
+    },
+	"rank": 5,
+	"toxicity": 8,
+	"extensions": {
+	  "extension-definition--d83fce45-ef58-4c6c-a3f4-1fbc32e98c6e": {
+		"extension_type": "toplevel-property-extension"
+	  }
+	}
+}`
+
+const scoWithTopLevelAttributes = `{
+    "type": "url",
+    "spec_version": "2.1",
+    "id": "url--c1477287-23ac-5971-a010-5c287877fa60",
+    "value": "https://example.com/research/index.html",
+	"rank": 5,
+	"toxicity": 8,
+	"extensions": {
+	  "extension-definition--d83fce45-ef58-4c6c-a3f4-1fbc32e98c6e": {
+		"extension_type": "toplevel-property-extension"
+	  }
+	}
+}`
+
+const sroWithTopLevelAttributes = `{
+    "type": "sighting",
+    "spec_version": "2.1",
+    "id": "sighting--ee20065d-2555-424f-ad9e-0f8428623c75",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "created": "2016-04-06T20:08:31.000Z",
+    "modified": "2016-04-06T20:08:31.000Z",
+    "first_seen": "2015-12-21T19:00:00Z",
+    "last_seen": "2015-12-21T19:00:00Z",
+    "count": 50,
+    "sighting_of_ref": "indicator--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
+    "observed_data_refs": [
+      "observed-data--b67d30ff-02ac-498a-92f9-32f845f448cf"
+    ],
+    "where_sighted_refs": ["identity--b67d30ff-02ac-498a-92f9-32f845f448ff"],
+	"rank": 5,
+	"toxicity": 8,
+	"extensions": {
+	  "extension-definition--d83fce45-ef58-4c6c-a3f4-1fbc32e98c6e": {
+		"extension_type": "toplevel-property-extension"
+	  }
+	}
+}`

--- a/extension_test.go
+++ b/extension_test.go
@@ -1,0 +1,53 @@
+package stix2
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtensionJSONParsing(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("invalid-extension-format", func(t *testing.T) {
+		data := []byte(`{
+			"type": "network-traffic",
+			"spec_version": "2.1",
+			"id": "network-traffic--09ca55c3-97e5-5966-bad0-1d41d557ae13",
+			"src_ref": "ipv4-addr--89830c10-2e94-57fa-8ca6-e0537d2719d1",
+			"dst_ref": "ipv4-addr--45f4c6fb-2d7d-576a-a571-edc78d899a72",
+			"src_port": 3372,
+			"dst_port": 80,
+			"protocols": ["tcp"],
+			"extensions": {
+				"invalid": "string"
+		  }
+		}
+`)
+
+		var obj *NetworkTraffic
+		err := json.Unmarshal(data, &obj)
+		assert.Error(err, fmt.Sprintf("Value: %+v", obj))
+	})
+
+	t.Run("invalid-extension-format", func(t *testing.T) {
+		data := []byte(`{
+		"type": "network-traffic",
+		"spec_version": "2.1",
+		"id": "network-traffic--09ca55c3-97e5-5966-bad0-1d41d557ae13",
+		"src_ref": "ipv4-addr--89830c10-2e94-57fa-8ca6-e0537d2719d1",
+		"dst_ref": "ipv4-addr--45f4c6fb-2d7d-576a-a571-edc78d899a72",
+		"src_port": 3372,
+		"dst_port": 80,
+		"protocols": ["tcp"],
+		"extensions": "string"
+	}
+`)
+
+		var obj *NetworkTraffic
+		err := json.Unmarshal(data, &obj)
+		assert.Error(err)
+	})
+}

--- a/extension_test.go
+++ b/extension_test.go
@@ -217,6 +217,13 @@ func TestExtensionCustomObject(t *testing.T) {
 		assert.Nil(custom.Get("does_not_exist"))
 		assert.NotNil(custom.GetCreated())
 		assert.NotNil(custom.GetModified())
+
+		objects := c.GetAll(STIXType("my-favorite-sdo"))
+		assert.NotNil(objects)
+		assert.Len(objects, 1)
+
+		noObjects := c.GetAll(STIXType("sdo-does-not-exist"))
+		assert.Nil(noObjects)
 	})
 
 	t.Run("allow-ignoring-custom-objects", func(t *testing.T) {

--- a/extension_test.go
+++ b/extension_test.go
@@ -261,6 +261,12 @@ func TestExtensionCustomObject(t *testing.T) {
 		assert.Equal(Identifier(""), obj.GetID(), "should return empty string if not set")
 		assert.Nil(obj.GetExtendedTopLevelProperties(), "should always return nil")
 	})
+
+	t.Run("json-marshal-handler-should-return-error", func(t *testing.T) {
+		obj := &CustomObject{}
+		_, err := marshalToJSONHelper(obj)
+		assert.Error(err)
+	})
 }
 
 func TestExtensionTopLevelProperties(t *testing.T) {

--- a/file.go
+++ b/file.go
@@ -52,6 +52,10 @@ type File struct {
 	Content Identifier `json:"content_ref,omitempty"`
 }
 
+func (o *File) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // ArchiveExtension returns the archive extension for the object or nil.
 func (f *File) ArchiveExtension() *ArchiveFileExtension {
 	data, ok := f.Extensions[ExtArchive]

--- a/file.go
+++ b/file.go
@@ -4,7 +4,6 @@
 package stix2
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -59,9 +58,7 @@ func (f *File) ArchiveExtension() *ArchiveFileExtension {
 	if !ok {
 		return nil
 	}
-	var v ArchiveFileExtension
-	json.Unmarshal(data, &v)
-	return &v
+	return data.(*ArchiveFileExtension)
 }
 
 // NTFSExtension returns the NTFS extension for the object or nil.
@@ -70,9 +67,7 @@ func (f *File) NTFSExtension() *NTFSFileExtension {
 	if !ok {
 		return nil
 	}
-	var v NTFSFileExtension
-	json.Unmarshal(data, &v)
-	return &v
+	return data.(*NTFSFileExtension)
 }
 
 // PDFExtension returns the PDF extension for the object or nil.
@@ -81,9 +76,7 @@ func (f *File) PDFExtension() *PDFExtension {
 	if !ok {
 		return nil
 	}
-	var v PDFExtension
-	json.Unmarshal(data, &v)
-	return &v
+	return data.(*PDFExtension)
 }
 
 // RasterImageExtension returns the raster image extension for the object or nil.
@@ -92,9 +85,7 @@ func (f *File) RasterImageExtension() *RasterImageExtension {
 	if !ok {
 		return nil
 	}
-	var v RasterImageExtension
-	json.Unmarshal(data, &v)
-	return &v
+	return data.(*RasterImageExtension)
 }
 
 // WindowsPEBinaryExtension returns the Windows PE binary extension for the
@@ -104,9 +95,7 @@ func (f *File) WindowsPEBinaryExtension() *WindowsPEBinaryExtension {
 	if !ok {
 		return nil
 	}
-	var v WindowsPEBinaryExtension
-	json.Unmarshal(data, &v)
-	return &v
+	return data.(*WindowsPEBinaryExtension)
 }
 
 // NewFile creates a new File object. A File object MUST contain at least one
@@ -136,7 +125,7 @@ func NewFile(name string, hashes Hashes, opts ...STIXOption) (*File, error) {
 	if obj.ParentDirectory != "" {
 		idContri = append(idContri, fmt.Sprintf(`"%s"`, obj.ParentDirectory))
 	}
-	obj.ID = NewObservableIdenfier(fmt.Sprintf("[%s]", strings.Join(idContri, ",")), TypeFile)
+	obj.ID = NewObservableIdentifier(fmt.Sprintf("[%s]", strings.Join(idContri, ",")), TypeFile)
 	return obj, err
 }
 

--- a/file_test.go
+++ b/file_test.go
@@ -45,7 +45,6 @@ func TestFile(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 			//
 			OptionSize(size),
 			OptionNameEnc(someString),

--- a/grouping.go
+++ b/grouping.go
@@ -34,6 +34,10 @@ type Grouping struct {
 	Objects []Identifier `json:"object_refs"`
 }
 
+func (o *Grouping) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewGrouping creates a new Grouping object.
 func NewGrouping(context string, objects []Identifier, opts ...STIXOption) (*Grouping, error) {
 	if context == "" || len(objects) < 1 {

--- a/identity.go
+++ b/identity.go
@@ -34,6 +34,10 @@ type Identity struct {
 	ContactInformation string `json:"contact_information,omitempty"`
 }
 
+func (o *Identity) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // AddLocatedAt creates a relationship to a location hat the Identity is
 // located at or in the related Location.
 func (c *Identity) AddLocatedAt(id Identifier, opts ...STIXOption) (*Relationship, error) {

--- a/indicator.go
+++ b/indicator.go
@@ -24,7 +24,7 @@ type Indicator struct {
 	Description string `json:"description,omitempty"`
 	// Types is an open vocabulary that specifies a set of
 	// categorizations for this indicator.
-	Types []string `json:"indicator_types"`
+	Types []string `json:"indicator_types,omitempty"`
 	// Pattern is the detection pattern for this Indicator.
 	Pattern string `json:"pattern"`
 	// PatternType is the type of pattern used in this indicator. The property
@@ -45,6 +45,10 @@ type Indicator struct {
 	// KillChainPhases is the kill chain phase(s) to which this Indicator
 	// corresponds.
 	KillChainPhase []*KillChainPhase `json:"kill_chain_phases,omitempty"`
+}
+
+func (o *Indicator) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
 }
 
 // AddIndicates creates a relationship that describes that the Indicator can

--- a/infrastructure.go
+++ b/infrastructure.go
@@ -35,6 +35,10 @@ type Infrastructure struct {
 	LastSeen *Timestamp `json:"last_seen,omitempty"`
 }
 
+func (o *Infrastructure) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // AddConsistsOf documents the objects that are used to make up an
 // infrastructure instance, such as ipv4-addr, ipv6-addr, domain-name, url. An
 // infrastructure instance consists of zero or more objects.

--- a/intrusion-set.go
+++ b/intrusion-set.go
@@ -73,6 +73,10 @@ type IntrusionSet struct {
 	SecondaryMotivations []string `json:"secondary_motivations,omitempty"`
 }
 
+func (o *IntrusionSet) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // AddAttributedTo describes that the related Threat Actor is involved in
 // carrying out the Intrusion Set.
 func (c *IntrusionSet) AddAttributedTo(id Identifier, opts ...STIXOption) (*Relationship, error) {

--- a/ip.go
+++ b/ip.go
@@ -51,7 +51,7 @@ func NewIPv4Address(value string, opts ...STIXOption) (*IPv4Address, error) {
 	}
 
 	err := applyOptions(obj, opts)
-	obj.ID = NewObservableIdenfier(fmt.Sprintf("[\"%s\"]", value), TypeIPv4Addr)
+	obj.ID = NewObservableIdentifier(fmt.Sprintf("[\"%s\"]", value), TypeIPv4Addr)
 	return obj, err
 }
 
@@ -101,6 +101,6 @@ func NewIPv6Address(value string, opts ...STIXOption) (*IPv6Address, error) {
 	}
 
 	err := applyOptions(obj, opts)
-	obj.ID = NewObservableIdenfier(fmt.Sprintf("[\"%s\"]", value), TypeIPv6Addr)
+	obj.ID = NewObservableIdentifier(fmt.Sprintf("[\"%s\"]", value), TypeIPv6Addr)
 	return obj, err
 }

--- a/ip.go
+++ b/ip.go
@@ -21,6 +21,10 @@ type IPv4Address struct {
 	BelongsTo []Identifier `json:"belongs_to_refs,omitempty"`
 }
 
+func (o *IPv4Address) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // AddResolvesTo describes that this IPv4Address resolves to one or more Layer
 // 2 Media Access Control (MAC) addresses.
 func (c *IPv4Address) AddResolvesTo(id Identifier, opts ...STIXOption) (*Relationship, error) {
@@ -69,6 +73,10 @@ type IPv6Address struct {
 	// BelongsTo specifies a list of references to one or more autonomous
 	// systems (AS) that the IPv6 address belongs to.
 	BelongsTo []Identifier `json:"belongs_to_refs,omitempty"`
+}
+
+func (o *IPv6Address) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
 }
 
 // AddResolvesTo describes that this IPv6Address resolves to one or more Layer

--- a/ip_test.go
+++ b/ip_test.go
@@ -37,7 +37,6 @@ func TestIPv4Address(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 		}
 		obj, err := NewIPv4Address(val, opts...)
 		assert.NotNil(obj)
@@ -158,7 +157,6 @@ func TestIPv6Address(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 		}
 		obj, err := NewIPv6Address(val, opts...)
 		assert.NotNil(obj)

--- a/location.go
+++ b/location.go
@@ -78,6 +78,10 @@ type Location struct {
 	PostalCode string `json:"postal_code,omitempty"`
 }
 
+func (o *Location) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewLocation creates a new Location object.
 func NewLocation(region, country string, lat, long float64, opts ...STIXOption) (*Location, error) {
 	if region == "" && country == "" && lat == float64(0) && long == float64(0) {

--- a/mac.go
+++ b/mac.go
@@ -12,6 +12,10 @@ type MACAddress struct {
 	Value string `json:"value"`
 }
 
+func (o *MACAddress) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewMACAddress creates a new MACAddress object.
 func NewMACAddress(value string, opts ...STIXOption) (*MACAddress, error) {
 	if value == "" {

--- a/mac.go
+++ b/mac.go
@@ -24,6 +24,6 @@ func NewMACAddress(value string, opts ...STIXOption) (*MACAddress, error) {
 	}
 
 	err := applyOptions(obj, opts)
-	obj.ID = NewObservableIdenfier(fmt.Sprintf("[\"%s\"]", value), TypeMACAddress)
+	obj.ID = NewObservableIdentifier(fmt.Sprintf("[\"%s\"]", value), TypeMACAddress)
 	return obj, err
 }

--- a/mac_test.go
+++ b/mac_test.go
@@ -37,7 +37,6 @@ func TestMACAddress(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 		}
 		obj, err := NewMACAddress(val, opts...)
 		assert.NotNil(obj)

--- a/malware-analysis.go
+++ b/malware-analysis.go
@@ -79,6 +79,10 @@ type MalwareAnalysis struct {
 	Sample Identifier `json:"sample_ref,omitempty"`
 }
 
+func (o *MalwareAnalysis) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // AddCharacterizes describes that the malware analysis is describes the
 // related malware.
 func (c *MalwareAnalysis) AddCharacterizes(id Identifier, opts ...STIXOption) (*Relationship, error) {

--- a/malware.go
+++ b/malware.go
@@ -75,6 +75,10 @@ type Malware struct {
 	Samples []Identifier `json:"sample_refs,omitempty"`
 }
 
+func (o *Malware) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // AddAuthoredBy describes that the malware instance or family was developed by
 // the related threat actor or intrusion set.
 func (c *Malware) AddAuthoredBy(id Identifier, opts ...STIXOption) (*Relationship, error) {

--- a/malware_test.go
+++ b/malware_test.go
@@ -36,7 +36,7 @@ func TestMalware(t *testing.T) {
 		typs := []string{MalwareTypeBot}
 		aliases := []string{"Name 1", "Name 2"}
 		kcf := []*KillChainPhase{{}}
-		os := []Identifier{NewObservableIdenfier("Windows", TypeSoftware)}
+		os := []Identifier{NewObservableIdentifier("Windows", TypeSoftware)}
 		arch := []string{ArchitectureX8664}
 		langu := []string{ImplementationLanguageGo}
 		capa := []string{MalwareCapabilitiesCommunicatesWithC2}

--- a/meta.go
+++ b/meta.go
@@ -128,6 +128,18 @@ type LanguageContent struct {
 	// in the target or to properties that do not exist in the target object
 	// MUST be ignored.
 	Contents map[string]map[string]interface{} `json:"contents"`
+
+	toplevelProperties *CustomObject
+}
+
+func (s *LanguageContent) addCustomProperties(c *CustomObject) {
+	s.toplevelProperties = c
+}
+
+// GetExtendedTopLevelProperties returns the extra top level properties or
+// nil for the object.
+func (s *LanguageContent) GetExtendedTopLevelProperties() *CustomObject {
+	return s.toplevelProperties
 }
 
 // GetID returns the identifier for the object.
@@ -248,6 +260,18 @@ type MarkingDefinition struct {
 	// Definition contains the marking object itself (e.g., the TLP marking,
 	// the Statement, or some other marking definition defined).
 	Definition interface{} `json:"definition"`
+
+	toplevelProperties *CustomObject
+}
+
+func (s *MarkingDefinition) addCustomProperties(c *CustomObject) {
+	s.toplevelProperties = c
+}
+
+// GetExtendedTopLevelProperties returns the extra top level properties or
+// nil for the object.
+func (s *MarkingDefinition) GetExtendedTopLevelProperties() *CustomObject {
+	return s.toplevelProperties
 }
 
 // GetID returns the identifier for the object.

--- a/meta.go
+++ b/meta.go
@@ -85,6 +85,8 @@ type LanguageContent struct {
 	// Marking Definition object (i.e., it cannot contain any circular
 	// references).
 	GranularMarking []*GranularMarking `json:"granular_markings,omitempty"`
+	// Specifies any extensions of the object, as a dictionary.
+	Extensions Extensions `json:"extensions,omitempty"`
 	// Object identifies the id of the object that this Language Content
 	// applies to. It MUST be the identifier for a STIX Object.
 	Object Identifier `json:"object_ref"`
@@ -236,6 +238,8 @@ type MarkingDefinition struct {
 	// Marking Definition object (i.e., it cannot contain any circular
 	// references).
 	GranularMarking []*GranularMarking `json:"granular_markings,omitempty"`
+	// Specifies any extensions of the object, as a dictionary.
+	Extensions Extensions `json:"extensions,omitempty"`
 	// Name is used to identify the Marking Definition.
 	Name string `json:"name,omitempty"`
 	// DefinitionType identifies the type of Marking Definition. The value of

--- a/meta.go
+++ b/meta.go
@@ -132,6 +132,10 @@ type LanguageContent struct {
 	toplevelProperties *CustomObject
 }
 
+func (o *LanguageContent) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 func (s *LanguageContent) addCustomProperties(c *CustomObject) {
 	s.toplevelProperties = c
 }
@@ -262,6 +266,10 @@ type MarkingDefinition struct {
 	Definition interface{} `json:"definition"`
 
 	toplevelProperties *CustomObject
+}
+
+func (o *MarkingDefinition) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
 }
 
 func (s *MarkingDefinition) addCustomProperties(c *CustomObject) {

--- a/mutex.go
+++ b/mutex.go
@@ -12,6 +12,10 @@ type Mutex struct {
 	Name string `json:"name"`
 }
 
+func (o *Mutex) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewMutex creates a new Mutex object.
 func NewMutex(value string, opts ...STIXOption) (*Mutex, error) {
 	if value == "" {

--- a/mutex.go
+++ b/mutex.go
@@ -24,6 +24,6 @@ func NewMutex(value string, opts ...STIXOption) (*Mutex, error) {
 	}
 
 	err := applyOptions(obj, opts)
-	obj.ID = NewObservableIdenfier(fmt.Sprintf("[\"%s\"]", value), TypeMutex)
+	obj.ID = NewObservableIdentifier(fmt.Sprintf("[\"%s\"]", value), TypeMutex)
 	return obj, err
 }

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -37,7 +37,6 @@ func TestMutex(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 		}
 		obj, err := NewMutex(val, opts...)
 		assert.NotNil(obj)

--- a/network.go
+++ b/network.go
@@ -88,6 +88,10 @@ type NetworkTraffic struct {
 	Encapsulated Identifier `json:"encapsulated_by_ref,omitempty"`
 }
 
+func (o *NetworkTraffic) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // HTTPRequestExtension returns the HTTP request extension for the object or
 // nil.
 func (n *NetworkTraffic) HTTPRequestExtension() *HTTPRequestExtension {

--- a/network.go
+++ b/network.go
@@ -4,7 +4,6 @@
 package stix2
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -96,9 +95,7 @@ func (n *NetworkTraffic) HTTPRequestExtension() *HTTPRequestExtension {
 	if !ok {
 		return nil
 	}
-	var v HTTPRequestExtension
-	json.Unmarshal(data, &v)
-	return &v
+	return data.(*HTTPRequestExtension)
 }
 
 // ICMPExtension returns the ICMP extension for the object or nil.
@@ -107,9 +104,7 @@ func (n *NetworkTraffic) ICMPExtension() *ICMPExtension {
 	if !ok {
 		return nil
 	}
-	var v ICMPExtension
-	json.Unmarshal(data, &v)
-	return &v
+	return data.(*ICMPExtension)
 }
 
 // SocketExtension returns the socket extension for the object or nil.
@@ -118,9 +113,7 @@ func (n *NetworkTraffic) SocketExtension() *SocketExtension {
 	if !ok {
 		return nil
 	}
-	var v SocketExtension
-	json.Unmarshal(data, &v)
-	return &v
+	return data.(*SocketExtension)
 }
 
 // TCPExtension returns the tcp extension for the object or nil.
@@ -129,9 +122,7 @@ func (n *NetworkTraffic) TCPExtension() *TCPExtension {
 	if !ok {
 		return nil
 	}
-	var v TCPExtension
-	json.Unmarshal(data, &v)
-	return &v
+	return data.(*TCPExtension)
 }
 
 // NewNetworkTraffic creates a new NetworkTraffic object. A NetworkTraffic object MUST contain at least one
@@ -164,7 +155,7 @@ func NewNetworkTraffic(proto []string, opts ...STIXOption) (*NetworkTraffic, err
 		idContri = append(idContri, fmt.Sprintf("%d", obj.DstPort))
 	}
 	idContri = append(idContri, fmt.Sprintf(`["%s"]`, strings.Join(obj.Protocols, `","`)))
-	obj.ID = NewObservableIdenfier(fmt.Sprintf("[%s]", strings.Join(idContri, ",")), TypeNetworkTraffic)
+	obj.ID = NewObservableIdentifier(fmt.Sprintf("[%s]", strings.Join(idContri, ",")), TypeNetworkTraffic)
 	return obj, err
 }
 

--- a/network_test.go
+++ b/network_test.go
@@ -307,6 +307,12 @@ func TestNetworkTraffic(t *testing.T) {
 		assert.True(ext.IsListening)
 	})
 
+	t.Run("socket-type-marshal", func(t *testing.T) {
+		b, err := json.Marshal(SocketTypeStream)
+		assert.NoError(err)
+		assert.Equal([]byte(`"SOCK_STREAM"`), b)
+	})
+
 	t.Run("socket-type-unmarshal-short", func(t *testing.T) {
 		d1 := []byte("A")
 		var typ SocketType
@@ -332,5 +338,88 @@ func TestNetworkTraffic(t *testing.T) {
 		err := ptr.UnmarshalJSON(d1)
 		assert.NoError(err)
 		assert.Equal(SocketFamilyUnknownValue, typ)
+	})
+
+	t.Run("HTTP-ext-parse", func(t *testing.T) {
+		data := []byte(`{
+			"type": "network-traffic",
+			"spec_version": "2.1",
+			"id": "network-traffic--f8ae967a-3dc3-5cdf-8f94-8505abff00c2",
+			"dst_ref": "ipv4-addr--6da8dad3-4de3-5f8e-ab23-45d0b8f12f16",
+			"protocols": ["tcp", "http"],
+			"extensions": {
+			  "http-request-ext": {
+				"request_method": "get",
+				"request_value": "/download.html",
+				"request_version": "http/1.1",
+				"request_header": {
+				  "Accept-Encoding": ["gzip,deflate"],
+				  "User-Agent": ["Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.6) Gecko/20040113"],
+				  "Host": ["www.example.com"]
+				}
+			  }
+			}
+		  }
+`)
+		var obj *NetworkTraffic
+		err := json.Unmarshal(data, &obj)
+		assert.NoError(err)
+
+		ext := obj.HTTPRequestExtension()
+		assert.NotNil(ext)
+		assert.Equal("get", ext.Method)
+	})
+
+	t.Run("ICMP-parsing", func(t *testing.T) {
+		data := []byte(`{
+			"type": "network-traffic",
+			"spec_version": "2.1",
+			"id": "network-traffic--e7a939ca-78c6-5f27-8ae0-4ad112454626",
+			"src_ref": "ipv4-addr--d7177770-fc12-586b-9244-426596a7008e",
+			"dst_ref": "ipv4-addr--03b708d9-7761-5523-ab75-5ea096294a68",
+			"protocols": ["icmp"],
+			"extensions": {
+			  "icmp-ext": {
+				"icmp_type_hex": "08",
+				"icmp_code_hex": "00"
+			  }
+			}
+		  }
+`)
+
+		var obj *NetworkTraffic
+		err := json.Unmarshal(data, &obj)
+		assert.NoError(err)
+
+		ext := obj.ICMPExtension()
+		assert.NotNil(ext)
+		assert.Equal(Hex("08"), ext.Type)
+	})
+
+	t.Run("parse-tcp-ext", func(t *testing.T) {
+		data := []byte(`{
+			"type": "network-traffic",
+			"spec_version": "2.1",
+			"id": "network-traffic--09ca55c3-97e5-5966-bad0-1d41d557ae13",
+			"src_ref": "ipv4-addr--89830c10-2e94-57fa-8ca6-e0537d2719d1",
+			"dst_ref": "ipv4-addr--45f4c6fb-2d7d-576a-a571-edc78d899a72",
+			"src_port": 3372,
+			"dst_port": 80,
+			"protocols": ["tcp"],
+			"extensions": {
+			  "tcp-ext": {
+				"src_flags_hex": "00000002"
+			  }
+			}
+		  }
+`)
+
+		var obj *NetworkTraffic
+		err := json.Unmarshal(data, &obj)
+		assert.NoError(err)
+
+		ext := obj.TCPExtension()
+		assert.NotNil(ext)
+		assert.Equal(Hex("00000002"), ext.SrcFlags)
 	})
 }

--- a/network_test.go
+++ b/network_test.go
@@ -43,7 +43,6 @@ func TestNetworkTraffic(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 			//
 			OptionStart(ts),
 			OptionEnd(ts),

--- a/note.go
+++ b/note.go
@@ -27,6 +27,10 @@ type Note struct {
 	Objects []Identifier `json:"object_refs"`
 }
 
+func (o *Note) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewNote creates a new Note object.
 func NewNote(content string, objects []Identifier, opts ...STIXOption) (*Note, error) {
 	if len(objects) == 0 {

--- a/object.go
+++ b/object.go
@@ -236,7 +236,9 @@ type STIXDomainObject struct {
 	// Marking Definition object (i.e., it cannot contain any circular
 	// references).
 	GranularMarking []*GranularMarking `json:"granular_markings,omitempty"`
-	// Specifies any extensions of the object, as a dictionary.
+	// Specifies any extensions of the object, as a dictionary. The values of
+	// the dictionary is either one of the extension types defined by the STIX
+	// specification or a *CustomObject.
 	Extensions Extensions `json:"extensions,omitempty"`
 }
 

--- a/object.go
+++ b/object.go
@@ -5,6 +5,7 @@ package stix2
 
 import (
 	"bytes"
+	"encoding/json"
 	"time"
 
 	"github.com/ugorji/go/codec"
@@ -417,4 +418,14 @@ func newSTIXCyberObservableObject(typ STIXType) STIXCyberObservableObject {
 		Type:        typ,
 		SpecVersion: SpecVersion21,
 	}
+}
+
+func marshalToJSONHelper(obj STIXObject) ([]byte, error) {
+	// There are some extra top level properties that needs to be handled.
+	// Convert to a map to retain correct JSON structure.
+	m, err := objectToMap(obj)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(m)
 }

--- a/object.go
+++ b/object.go
@@ -113,6 +113,12 @@ type STIXRelationshipObject struct {
 	GranularMarking []*GranularMarking `json:"granular_markings,omitempty"`
 	// Specifies any extensions of the object, as a dictionary.
 	Extensions Extensions `json:"extensions,omitempty"`
+
+	toplevelProperties *CustomObject
+}
+
+func (s *STIXRelationshipObject) addCustomProperties(c *CustomObject) {
+	s.toplevelProperties = c
 }
 
 // GetID returns the identifier for the object.
@@ -141,6 +147,12 @@ func (s *STIXRelationshipObject) GetModified() *time.Time {
 		return nil
 	}
 	return &s.Modified.Time
+}
+
+// GetExtendedTopLevelProperties returns the extra top level properties or
+// nil for the object.
+func (s *STIXRelationshipObject) GetExtendedTopLevelProperties() *CustomObject {
+	return s.toplevelProperties
 }
 
 func newSTIXDomainObject(typ STIXType) STIXDomainObject {
@@ -240,6 +252,18 @@ type STIXDomainObject struct {
 	// the dictionary is either one of the extension types defined by the STIX
 	// specification or a *CustomObject.
 	Extensions Extensions `json:"extensions,omitempty"`
+
+	toplevelProperties *CustomObject
+}
+
+func (s *STIXDomainObject) addCustomProperties(c *CustomObject) {
+	s.toplevelProperties = c
+}
+
+// GetExtendedTopLevelProperties returns the extra top level properties or
+// nil for the object.
+func (s *STIXDomainObject) GetExtendedTopLevelProperties() *CustomObject {
+	return s.toplevelProperties
 }
 
 // AddDerivedFrom adds a relationship to an object that this object is derived
@@ -321,6 +345,18 @@ type STIXCyberObservableObject struct {
 	Defanged bool `json:"defanged,omitempty"`
 	// Specifies any extensions of the object, as a dictionary.
 	Extensions Extensions `json:"extensions,omitempty"`
+
+	toplevelProperties *CustomObject
+}
+
+func (s *STIXCyberObservableObject) addCustomProperties(c *CustomObject) {
+	s.toplevelProperties = c
+}
+
+// GetExtendedTopLevelProperties returns the extra top level properties or
+// nil for the object.
+func (s *STIXCyberObservableObject) GetExtendedTopLevelProperties() *CustomObject {
+	return s.toplevelProperties
 }
 
 // AddDerivedFrom adds a relationship to an object that this object is derived

--- a/object.go
+++ b/object.go
@@ -111,6 +111,8 @@ type STIXRelationshipObject struct {
 	// Marking Definition object (i.e., it cannot contain any circular
 	// references).
 	GranularMarking []*GranularMarking `json:"granular_markings,omitempty"`
+	// Specifies any extensions of the object, as a dictionary.
+	Extensions Extensions `json:"extensions,omitempty"`
 }
 
 // GetID returns the identifier for the object.
@@ -234,6 +236,8 @@ type STIXDomainObject struct {
 	// Marking Definition object (i.e., it cannot contain any circular
 	// references).
 	GranularMarking []*GranularMarking `json:"granular_markings,omitempty"`
+	// Specifies any extensions of the object, as a dictionary.
+	Extensions Extensions `json:"extensions,omitempty"`
 }
 
 // AddDerivedFrom adds a relationship to an object that this object is derived

--- a/object.go
+++ b/object.go
@@ -5,7 +5,6 @@ package stix2
 
 import (
 	"bytes"
-	"encoding/json"
 	"time"
 
 	"github.com/ugorji/go/codec"
@@ -315,7 +314,7 @@ type STIXCyberObservableObject struct {
 	// object has been defanged.
 	Defanged bool `json:"defanged,omitempty"`
 	// Specifies any extensions of the object, as a dictionary.
-	Extensions map[string]json.RawMessage `json:"extensions,omitempty"`
+	Extensions Extensions `json:"extensions,omitempty"`
 }
 
 // AddDerivedFrom adds a relationship to an object that this object is derived

--- a/observed-data.go
+++ b/observed-data.go
@@ -79,6 +79,10 @@ type ObservedData struct {
 	ObjectRefs []Identifier `json:"object_refs,omitempty"`
 }
 
+func (o *ObservedData) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewObservedData creates a new ObservedData object.
 func NewObservedData(firstObserved, lastObserved *Timestamp, numberObserved int64, objectsRef []Identifier, opts ...STIXOption) (*ObservedData, error) {
 	if len(objectsRef) == 0 || firstObserved == nil || lastObserved == nil || numberObserved < 1 {

--- a/opinion.go
+++ b/opinion.go
@@ -41,6 +41,10 @@ type Opinion struct {
 	Objects []Identifier `json:"object_refs"`
 }
 
+func (o *Opinion) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewOpinion creates a new Opinion object.
 func NewOpinion(val OpinionValue, objects []Identifier, opts ...STIXOption) (*Opinion, error) {
 	if len(objects) == 0 {

--- a/option.go
+++ b/option.go
@@ -178,6 +178,14 @@ func OptionExtension(name string, value interface{}) STIXOption {
 	}
 }
 
+// OptionExtensionProperties adds an extension. This option is valid for the types:
+//		- STIX ExtensionDefinition
+func OptionExtensionProperties(value []string) STIXOption {
+	return func(obj STIXObject) error {
+		return setField(obj, "ExtensionProperties", value, reflect.Slice)
+	}
+}
+
 /*
 	Other properties
 */

--- a/option.go
+++ b/option.go
@@ -1,3 +1,6 @@
+// Copyright 2021 Joakim Kennedy. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
 package stix2
 
 import (

--- a/option.go
+++ b/option.go
@@ -1,12 +1,8 @@
 package stix2
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"reflect"
-
-	"github.com/ugorji/go/codec"
 )
 
 // STIXOption is an optional parameter when constructing an
@@ -164,23 +160,16 @@ func OptionExtension(name string, value interface{}) STIXOption {
 			return fmt.Errorf("extension field not available in the object")
 		}
 
-		ext, ok := ev.Interface().(map[string]json.RawMessage)
+		ext, ok := ev.Interface().(Extensions)
 		if !ok {
 			return fmt.Errorf("extensions field is of wrong type")
 		}
 
 		if ext == nil {
-			ext = make(map[string]json.RawMessage)
+			ext = Extensions{}
 		}
 
-		// If error drop the data.
-		buf := &bytes.Buffer{}
-		c := codec.NewEncoder(buf, &codec.JsonHandle{})
-		err = c.Encode(value)
-		if err != nil {
-			return fmt.Errorf("error when processing extension data: %w", err)
-		}
-		ext[name] = json.RawMessage(buf.Bytes())
+		ext[name] = value
 
 		// Save the extensions field
 		ev.Set(reflect.ValueOf(ext))

--- a/option_test.go
+++ b/option_test.go
@@ -35,14 +35,13 @@ func TestCyberObservableOptions(t *testing.T) {
 		a.NoError(err)
 		a.Equal(gms, o.GranularMarking)
 
-		ext := struct {
-			TestField string
-		}{TestField: "test value"}
+		ext := map[string]string{}
+		ext["TestField"] = "test value"
 
 		err = OptionExtension("TestExtension", ext)(o)
 		a.NoError(err)
 		a.Len(o.Extensions, 1)
-		a.Contains(string(o.Extensions["TestExtension"]), "test value")
+		a.Contains(o.Extensions["TestExtension"].(map[string]string)["TestField"], "test value")
 	})
 
 	t.Run("nil_object", func(t *testing.T) {
@@ -115,13 +114,6 @@ func TestCyberObservableOptions(t *testing.T) {
 		err := OptionExtension("test", "")(obj)
 		a.Error(err)
 		a.Equal("extension field not available in the object", err.Error())
-	})
-
-	t.Run("extensions_bad_json_data", func(t *testing.T) {
-		obj := &testObject{}
-		err := OptionExtension("test", complex(42, 1337))(obj)
-		a.Error(err)
-		a.Equal("error when processing extension data: json encode error: unsupported kind complex128, for (42+1337i)", err.Error())
 	})
 
 	t.Run("extenstion_not_pinter_to_struct", func(t *testing.T) {

--- a/option_test.go
+++ b/option_test.go
@@ -132,6 +132,10 @@ func TestCyberObservableOptions(t *testing.T) {
 
 type emptryTestStruct struct{}
 
+func (s *emptryTestStruct) GetExtendedTopLevelProperties() *CustomObject {
+	panic("Failed")
+}
+
 func (s *emptryTestStruct) GetCreated() *time.Time {
 	panic("Failed")
 }
@@ -164,6 +168,10 @@ type structWithWrongFieldKind struct {
 }
 
 type badType string
+
+func (s *badType) GetExtendedTopLevelProperties() *CustomObject {
+	panic("Failed")
+}
 
 func (s *badType) GetCreated() *time.Time {
 	panic("Failed")

--- a/option_test.go
+++ b/option_test.go
@@ -89,7 +89,7 @@ func TestCyberObservableOptions(t *testing.T) {
 		obj := &structWithWrongKind{}
 		err := OptionExtension("tesst", "")(obj)
 		a.Error(err)
-		a.Equal("object is not a STIXCyberObservableObject", err.Error())
+		a.Equal("object can not have extensions", err.Error())
 	})
 
 	t.Run("extensions_wrong_extension_kind", func(t *testing.T) {
@@ -101,7 +101,7 @@ func TestCyberObservableOptions(t *testing.T) {
 		}{}
 		err := OptionExtension("test", "")(obj)
 		a.Error(err)
-		a.Equal("extensions field is of wrong type", err.Error())
+		a.Equal("object can not have extensions", err.Error())
 	})
 
 	t.Run("extensions_no_field", func(t *testing.T) {
@@ -113,7 +113,7 @@ func TestCyberObservableOptions(t *testing.T) {
 		}{}
 		err := OptionExtension("test", "")(obj)
 		a.Error(err)
-		a.Equal("extension field not available in the object", err.Error())
+		a.Equal("object can not have extensions", err.Error())
 	})
 
 	t.Run("extenstion_not_pinter_to_struct", func(t *testing.T) {

--- a/process.go
+++ b/process.go
@@ -44,6 +44,10 @@ type Process struct {
 	Child []Identifier `json:"child_refs,omitempty"`
 }
 
+func (o *Process) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // WindowsProcessExtension returns the Windows process extension for the object
 // or nil.
 func (n *Process) WindowsProcessExtension() *WindowsProcessExtension {

--- a/process.go
+++ b/process.go
@@ -4,7 +4,6 @@
 package stix2
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
@@ -52,9 +51,7 @@ func (n *Process) WindowsProcessExtension() *WindowsProcessExtension {
 	if !ok {
 		return nil
 	}
-	var v WindowsProcessExtension
-	json.Unmarshal(data, &v)
-	return &v
+	return data.(*WindowsProcessExtension)
 }
 
 // WindowsServiceExtension returns the Windows service extension for the object
@@ -64,9 +61,7 @@ func (n *Process) WindowsServiceExtension() *WindowsServiceExtension {
 	if !ok {
 		return nil
 	}
-	var v WindowsServiceExtension
-	json.Unmarshal(data, &v)
-	return &v
+	return data.(*WindowsServiceExtension)
 }
 
 // NewProcess creates a new Process object.

--- a/process_test.go
+++ b/process_test.go
@@ -36,7 +36,6 @@ func TestProcess(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 			//
 			OptionIsHidden(true),
 			OptionPID(testInt),

--- a/process_test.go
+++ b/process_test.go
@@ -80,6 +80,15 @@ func TestProcess(t *testing.T) {
 		assert.Len(f.Extensions, 1)
 		stored := f.WindowsProcessExtension()
 		assert.Equal(ext, stored)
+
+		// JSON encoding/decoding without errors.
+		data, err := f.MarshalJSON()
+		assert.NoError(err)
+		assert.NotNil(data)
+
+		var proc Process
+		err = json.Unmarshal(data, &proc)
+		assert.NoError(err)
 	})
 
 	t.Run("process-extension-nil", func(t *testing.T) {
@@ -100,6 +109,15 @@ func TestProcess(t *testing.T) {
 		assert.Len(f.Extensions, 1)
 		stored := f.WindowsServiceExtension()
 		assert.Equal(ext, stored)
+
+		// JSON encoding/decoding without errors.
+		data, err := f.MarshalJSON()
+		assert.NoError(err)
+		assert.NotNil(data)
+
+		var proc Process
+		err = json.Unmarshal(data, &proc)
+		assert.NoError(err)
 	})
 
 	t.Run("service-extension-nil", func(t *testing.T) {

--- a/regkey.go
+++ b/regkey.go
@@ -31,6 +31,10 @@ type RegistryKey struct {
 	NumberOfSubkeys int64 `json:"number_of_subkeys,omitempty"`
 }
 
+func (o *RegistryKey) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewRegistryKey creates a new RegistryKey object.
 func NewRegistryKey(opts ...STIXOption) (*RegistryKey, error) {
 	if len(opts) == 0 {

--- a/regkey.go
+++ b/regkey.go
@@ -54,7 +54,7 @@ func NewRegistryKey(opts ...STIXOption) (*RegistryKey, error) {
 		}
 		idContri = append(idContri, fmt.Sprintf(`%s`, strings.Join(a, ",")))
 	}
-	obj.ID = NewObservableIdenfier(fmt.Sprintf("[%s]", strings.Join(idContri, ",")), TypeRegistryKey)
+	obj.ID = NewObservableIdentifier(fmt.Sprintf("[%s]", strings.Join(idContri, ",")), TypeRegistryKey)
 	return obj, err
 }
 

--- a/regkey_test.go
+++ b/regkey_test.go
@@ -42,7 +42,6 @@ func TestRegistryKey(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 			//
 			OptionKey(testStr),
 			OptionValues(val),

--- a/relationship.go
+++ b/relationship.go
@@ -60,6 +60,10 @@ type Relationship struct {
 	StopTime *Timestamp `json:"stop_time,omitempty"`
 }
 
+func (o *Relationship) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewRelationship creates a new Relationship object.
 func NewRelationship(relType RelationshipType, source, target Identifier, opts ...STIXOption) (*Relationship, error) {
 	if relType == "" || source == "" || target == "" {

--- a/report.go
+++ b/report.go
@@ -35,6 +35,10 @@ type Report struct {
 	Objects []Identifier `json:"object_refs"`
 }
 
+func (o *Report) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewReport creates a new Report object.
 func NewReport(name string, published *Timestamp, objects []Identifier, opts ...STIXOption) (*Report, error) {
 	if name == "" || published == nil || len(objects) == 0 {

--- a/sighting.go
+++ b/sighting.go
@@ -98,6 +98,10 @@ type Sighting struct {
 	Summary bool `json:"summary,omitempty"`
 }
 
+func (o *Sighting) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewSighting creates a new Sighting of seen (s) Identifier.  Function returns
 // a wrapped error if ErrInvalidProperty if an optional property's value is
 // invalid according to the spec.

--- a/software.go
+++ b/software.go
@@ -55,6 +55,6 @@ func NewSoftware(name string, opts ...STIXOption) (*Software, error) {
 	if obj.Version != "" {
 		idContri = append(idContri, fmt.Sprintf(`"%s"`, obj.Version))
 	}
-	obj.ID = NewObservableIdenfier(fmt.Sprintf("[%s]", strings.Join(idContri, ",")), TypeSoftware)
+	obj.ID = NewObservableIdentifier(fmt.Sprintf("[%s]", strings.Join(idContri, ",")), TypeSoftware)
 	return obj, err
 }

--- a/software.go
+++ b/software.go
@@ -31,6 +31,10 @@ type Software struct {
 	Version string `json:"version,omitempty"`
 }
 
+func (o *Software) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewSoftware creates a new Software object. A Software object MUST contain at least one
 // of hashes or name.
 func NewSoftware(name string, opts ...STIXOption) (*Software, error) {

--- a/software_test.go
+++ b/software_test.go
@@ -37,7 +37,6 @@ func TestSoftware(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 			//
 			OptionCPE(testStr),
 			OptionSWID(testStr),

--- a/stix.go
+++ b/stix.go
@@ -144,6 +144,22 @@ func (c *Collection) AllObjects() []STIXObject {
 	return result
 }
 
+// GetAll returns all the items of the STIXType in the collection. This can
+// be used to return for example, custom types. Nil is returned if not types
+// are part of the collection.
+func (c *Collection) GetAll(typ STIXType) []STIXObject {
+	bucket, ok := c.objects[typ]
+	if !ok {
+		return nil
+	}
+
+	objects := make([]STIXObject, 0, len(bucket))
+	for _, v := range bucket {
+		objects = append(objects, v.(STIXObject))
+	}
+	return objects
+}
+
 // ToBundle returns a STIX bundle with all the STIXObjects in the Collection.
 func (c *Collection) ToBundle() (*Bundle, error) {
 	return NewBundle(c.AllObjects()...)

--- a/stix.go
+++ b/stix.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -39,7 +38,7 @@ func NoSortOption() CollectionOption {
 
 func DropCustomOption() CollectionOption {
 	return func(c *Collection) {
-		c.noSort = true
+		c.dropCustom = true
 	}
 }
 
@@ -58,7 +57,6 @@ func New(opts ...CollectionOption) *Collection {
 // STIX specification.
 type Collection struct {
 	objects map[STIXType]map[Identifier]interface{}
-	objinit sync.Once
 
 	// Options
 	noSort     bool

--- a/stix.go
+++ b/stix.go
@@ -300,6 +300,24 @@ func (c *Collection) EmailMessages() []*EmailMessage {
 	return data
 }
 
+// ExtensionDefinition returns the ExtensionDefinition with the identifier id.
+func (c *Collection) ExtensionDefinition(id Identifier) *ExtensionDefinition {
+	obj := c.getObject(TypeExtensionDefinition, id)
+	if obj == nil {
+		return nil
+	}
+	return obj.(*ExtensionDefinition)
+}
+
+// ExtensionDefinitions returns all the ExtensionDefinitions in the collection.
+func (c *Collection) ExtensionDefinitions() []*ExtensionDefinition {
+	data := make([]*ExtensionDefinition, 0, len(c.objects[TypeExtensionDefinition]))
+	for _, v := range c.objects[TypeExtensionDefinition] {
+		data = append(data, v.(*ExtensionDefinition))
+	}
+	return data
+}
+
 // File returns the File with the identifier id.
 func (c *Collection) File(id Identifier) *File {
 	obj := c.getObject(TypeFile, id)
@@ -932,6 +950,8 @@ func processObjects(collection *Collection, objects []json.RawMessage) error {
 			obj = &EmailAddress{}
 		case TypeEmailMessage:
 			obj = &EmailMessage{}
+		case TypeExtensionDefinition:
+			obj = &ExtensionDefinition{}
 		case TypeFile:
 			obj = &File{}
 		case TypeGrouping:

--- a/stix.go
+++ b/stix.go
@@ -80,14 +80,9 @@ func (c *Collection) Get(id Identifier) STIXObject {
 		// Incorrect format for the ID.
 		return nil
 	}
-	bucket, ok := c.objects[STIXType(parts[0])]
-	if !ok {
-		// No objects for this type.
-		return nil
-	}
-	obj, ok := bucket[id]
-	if !ok {
-		// No object with the ID.
+
+	obj := c.getObject(STIXType(parts[0]), id)
+	if obj == nil {
 		return nil
 	}
 	return obj.(STIXObject)

--- a/stix_test.go
+++ b/stix_test.go
@@ -4,6 +4,7 @@
 package stix2
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -298,6 +299,27 @@ func TestDuplicateInCollection(t *testing.T) {
 	col.Add(d)
 
 	assert.Len(t, col.AllObjects(), 1)
+}
+
+func TestJSONMarshal(t *testing.T) {
+	assert := assert.New(t)
+	f, err := getResource("all.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	data, err := ioutil.ReadAll(f)
+	require.NoError(t, err)
+
+	c, err := FromJSON(data)
+	assert.NoError(err)
+	assert.NotNil(c)
+
+	bundle, err := c.ToBundle()
+	assert.NoError(err)
+
+	buf, err := json.Marshal(bundle)
+	assert.NoError(err)
+	assert.NotNil(buf)
 }
 
 func getResource(file string) (*os.File, error) {

--- a/stix_test.go
+++ b/stix_test.go
@@ -322,6 +322,26 @@ func TestJSONMarshal(t *testing.T) {
 	assert.NotNil(buf)
 }
 
+func TestMarshalHandleErrorConditions(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("error-when-required-field-is-missing", func(t *testing.T) {
+		d, err := NewDomainName("example.com")
+		assert.NoError(err)
+		d.Value = ""
+		_, err = marshalToJSONHelper(d)
+		assert.Error(err)
+	})
+
+	t.Run("error-when-required-field-is-missing-in-parent", func(t *testing.T) {
+		d, err := NewDomainName("example.com")
+		assert.NoError(err)
+		d.ID = ""
+		_, err = marshalToJSONHelper(d)
+		assert.Error(err)
+	})
+}
+
 func getResource(file string) (*os.File, error) {
 	pth, err := filepath.Abs(filepath.Join("testresources", file))
 	if err != nil {

--- a/stix_test.go
+++ b/stix_test.go
@@ -111,6 +111,8 @@ func TestFromJSONAll(t *testing.T) {
 	assert.NotNil(c.EmailMessages())
 	assert.NotNil(c.EmailMessage(Identifier("email-message--cf9b4b7f-14c8-5955-8065-020e0316b559")))
 	assert.Nil(c.EmailMessage(Identifier("")))
+	assert.NotNil(c.ExtensionDefinition(Identifier("extension-definition--9c59fd79-4215-4ba2-920d-3e4f320e1e62")))
+	assert.Nil(c.ExtensionDefinition(Identifier("")))
 	assert.NotNil(c.Files())
 	assert.NotNil(c.File(Identifier("file--6ce09d9c-0ad3-5ebf-900c-e3cb288955b5")))
 	assert.Nil(c.File(Identifier("")))

--- a/testresources/all.json
+++ b/testresources/all.json
@@ -1,672 +1,664 @@
-[{
-      "type": "attack-pattern",
-      "spec_version": "2.1",
-      "id": "attack-pattern--7e33a43e-e34b-40ec-89da-36c9bb2cacd5",
-      "created": "2016-05-12T08:17:27.000Z",
-      "modified": "2016-05-12T08:17:27.000Z",
-      "name": "Spear Phishing as Practiced by Adversary X",
-      "description": "A particular form of spear phishing where the attacker claims that the target had won a contest, including personal details, to get them to click on a link.",
-      "external_references": [{
-         "source_name": "capec",
-         "external_id": "CAPEC-163"
-      }]
-   },
-   {
-      "type": "relationship",
-      "spec_version": "2.1",
-      "id": "relationship--57b56a43-b8b0-4cba-9deb-34e3e1faed9e",
-      "created": "2016-05-12T08:17:27.000Z",
-      "modified": "2016-05-12T08:17:27.000Z",
-      "relationship_type": "uses",
-      "source_ref": "intrusion-set--0c7e22ad-b099-4dc3-b0df-2ea3f49ae2e6",
-      "target_ref": "attack-pattern--7e33a43e-e34b-40ec-89da-36c9bb2cacd5"
-   },
-   {
-      "type": "intrusion-set",
-      "spec_version": "2.1",
-      "id": "intrusion-set--0c7e22ad-b099-4dc3-b0df-2ea3f49ae2e6",
-      "created": "2016-05-12T08:17:27.000Z",
-      "modified": "2016-05-12T08:17:27.000Z",
-      "name": "Adversary X"
-   },
-   {
-      "type": "campaign",
-      "spec_version": "2.1",
-      "id": "campaign--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "created": "2016-04-06T20:03:00.000Z",
-      "modified": "2016-04-06T20:03:00.000Z",
-      "name": "Green Group Attacks Against Finance",
-      "description": "Campaign by Green Group against a series of targets in the financial services sector."
-   },
-   {
-      "type": "course-of-action",
-      "spec_version": "2.1",
-      "id": "course-of-action--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "created": "2016-04-06T20:03:48.000Z",
-      "modified": "2016-04-06T20:03:48.000Z",
-      "name": "mitigation-poison-ivy-firewall",
-      "description": "This action points to a recommended set of steps to respond to the Poison Ivy malware on a Cisco firewall device",
-      "action_type": "cisco:ios",
-      "action_reference": {
-         "source_name": "internet",
-         "url": "hxxps://www.stopthebad.com/poisonivyresponse.asa"
+[
+  {
+    "type": "attack-pattern",
+    "spec_version": "2.1",
+    "id": "attack-pattern--7e33a43e-e34b-40ec-89da-36c9bb2cacd5",
+    "created": "2016-05-12T08:17:27.000Z",
+    "modified": "2016-05-12T08:17:27.000Z",
+    "name": "Spear Phishing as Practiced by Adversary X",
+    "description": "A particular form of spear phishing where the attacker claims that the target had won a contest, including personal details, to get them to click on a link.",
+    "external_references": [
+      {
+        "source_name": "capec",
+        "external_id": "CAPEC-163"
       }
-   },
-   {
-      "type": "relationship",
-      "spec_version": "2.1",
-      "id": "relationship--44298a74-ba52-4f0c-87a3-1824e67d7fad",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "created": "2016-04-06T20:07:10.000Z",
-      "modified": "2016-04-06T20:07:10.000Z",
-      "relationship_type": "mitigates",
-      "source_ref": "course-of-action--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
-      "target_ref": "malware--31b940d4-6f7f-459a-80ea-9c1f17b5891b"
-   },
-   {
-      "type": "malware",
-      "spec_version": "2.1",
-      "id": "malware--31b940d4-6f7f-459a-80ea-9c1f17b5891b",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "created": "2016-04-06T20:07:09.000Z",
-      "modified": "2016-04-06T20:07:09.000Z",
-      "name": "Poison Ivy",
-      "malware_types": [
-         "trojan"
-      ]
-   },
-   {
-      "type": "grouping",
-      "spec_version": "2.1",
-      "id": "grouping--84e4d88f-44ea-4bcd-bbf3-b2c1c320bcb3",
-      "created_by_ref": "identity--a463ffb3-1bd9-4d94-b02d-74e4f1658283",
-      "created": "2015-12-21T19:59:11.000Z",
-      "modified": "2015-12-21T19:59:11.000Z",
-      "name": "The Black Vine Cyberespionage Group",
-      "description": "A simple collection of Black Vine Cyberespionage Group attributed intel",
-      "context": "suspicious-activity",
-      "object_refs": [
-         "indicator--26ffb872-1dd9-446e-b6f5-d58527e5b5d2",
-         "campaign--83422c77-904c-4dc1-aff5-5c38f3a2c55c",
-         "relationship--f82356ae-fe6c-437c-9c24-6b64314ae68a",
-         "file--0203b5c8-f8b6-4ddb-9ad0-527d727f968b"
-      ]
-   },
-   {
-      "type": "identity",
-      "spec_version": "2.1",
-      "id": "identity--e5f1b90a-d9b6-40ab-81a9-8a29df4b6b65",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "created": "2016-04-06T20:03:00.000Z",
-      "modified": "2016-04-06T20:03:00.000Z",
-      "name": "ACME Widget, Inc.",
-      "identity_class": "organization"
-   },
-   {
-      "type": "indicator",
-      "spec_version": "2.1",
-      "id": "indicator--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "created": "2016-04-06T20:03:48.000Z",
-      "modified": "2016-04-06T20:03:48.000Z",
-      "indicator_types": [
-         "malicious-activity"
-      ],
-      "name": "Poison Ivy Malware",
-      "description": "This file is part of Poison Ivy",
-      "pattern": "[ file:hashes.'SHA-256' = '4bac27393bdd9777ce02453256c5577cd02275510b2227f473d03f533924f877' ]",
-      "pattern_type": "stix",
-      "valid_from": "2016-01-01T00:00:00Z"
-   },
-   {
-      "type": "relationship",
-      "spec_version": "2.1",
-      "id": "relationship--44298a74-ba52-4f0c-87a3-1824e67d7fad",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "created": "2016-04-06T20:06:37.000Z",
-      "modified": "2016-04-06T20:06:37.000Z",
-      "relationship_type": "indicates",
-      "source_ref": "indicator--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
-      "target_ref": "malware--31b940d4-6f7f-459a-80ea-9c1f17b5891b"
-   },
-   {
-      "type": "malware",
-      "spec_version": "2.1",
-      "id": "malware--31b940d4-6f7f-459a-80ea-9c1f17b5891b",
-      "created": "2016-04-06T20:07:09.000Z",
-      "modified": "2016-04-06T20:07:09.000Z",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "name": "Poison Ivy",
-      "malware_types": [
-         "trojan"
-      ]
-   },
-   {
-      "type": "infrastructure",
-      "spec_version": "2.1",
-      "id": "infrastructure--38c47d93-d984-4fd9-b87b-d69d0841628d",
-      "created": "2016-05-07T11:22:30.000Z",
-      "modified": "2016-05-07T11:22:30.000Z",
-      "name": "Poison Ivy C2",
-      "infrastructure_types": [
-         "command-and-control"
-      ]
-   }, {
-      "type": "relationship",
-      "spec_version": "2.1",
-      "id": "relationship--7aebe2f0-28d6-48a2-9c3e-b0aaa60266ed",
-      "created": "2016-05-09T08:17:27.000Z",
-      "modified": "2016-05-09T08:17:27.000Z",
-      "relationship_type": "controls",
-      "source_ref": "infrastructure--38c47d93-d984-4fd9-b87b-d69d0841628d",
-      "target_ref": "malware--16f4f3f9-1b68-4abb-bb66-7639d49f1e30"
-   }, {
-      "type": "malware",
-      "spec_version": "2.1",
-      "id": "malware--16f4f3f9-1b68-4abb-bb66-7639d49f1e30",
-      "created": "2016-05-08T14:31:09.000Z",
-      "modified": "2016-05-08T14:31:09.000Z",
-      "is_family": true,
-      "malware_types": [
-         "remote-access-trojan"
-      ],
-      "name": "Poison Ivy"
-   }, {
-      "type": "relationship",
-      "spec_version": "2.1",
-      "id": "relationship--7aebe2f0-28d6-48a2-9c3e-b0aaa60266ef",
-      "created": "2016-05-09T08:17:27.000Z",
-      "modified": "2016-05-09T08:17:27.000Z",
-      "relationship_type": "consists-of",
-      "source_ref": "infrastructure--38c47d93-d984-4fd9-b87b-d69d0841628d",
-      "target_ref": "ipv4-addr--b4e29b62-2053-47c4-bab4-bbce39e5ed67"
-   }, {
-      "type": "relationship",
-      "spec_version": "2.1",
-      "id": "relationship--7aebe2f0-28d6-48a2-9c3e-b0aaa60266ef",
-      "created": "2016-05-09T08:17:27.000Z",
-      "modified": "2016-05-09T08:17:27.000Z",
-      "relationship_type": "consists-of",
-      "source_ref": "infrastructure--38c47d93-d984-4fd9-b87b-d69d0841628d",
-      "target_ref": "ipv4-addr--84445275-e371-444b-baea-ac7d07a180fd"
-   }, {
-      "type": "ipv4-addr",
-      "spec_version": "2.1",
-      "id": "ipv4-addr--b4e29b62-2053-47c4-bab4-bbce39e5ed67",
-      "value": "198.51.100.3"
-   }, {
-      "type": "ipv4-addr",
-      "spec_version": "2.1",
-      "id": "ipv4-addr--84445275-e371-444b-baea-ac7d07a180fd",
-      "value": "198.52.200.4"
-   },
-   {
-      "type": "intrusion-set",
-      "spec_version": "2.1",
-      "id": "intrusion-set--4e78f46f-a023-4e5f-bc24-71b3ca22ec29",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "created": "2016-04-06T20:03:48.000Z",
-      "modified": "2016-04-06T20:03:48.000Z",
-      "name": "Bobcat Breakin",
-      "description": "Incidents usually feature a shared TTP of a bobcat being released within the building containing network access, scaring users to leave their computers without locking them first. Still determining where the threat actors are getting the bobcats.",
-      "aliases": [
-         "Zookeeper"
-      ],
-      "goals": [
-         "acquisition-theft",
-         "harassment",
-         "damage"
-      ]
-   },
-   {
-      "type": "location",
-      "spec_version": "2.1",
-      "id": "location--a6e9345f-5a15-4c29-8bb3-7dcc5d168d64",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "created": "2016-04-06T20:03:00.000Z",
-      "modified": "2016-04-06T20:03:00.000Z",
-      "region": "south-eastern-asia",
-      "country": "th",
-      "administrative_area": "Tak",
-      "postal_code": "63170"
-   },
-   {
-      "type": "note",
-      "spec_version": "2.1",
-      "id": "note--0c7b5b88-8ff7-4a4d-aa9d-feb398cd0061",
-      "created": "2016-05-12T08:17:27.000Z",
-      "modified": "2016-05-12T08:17:27.000Z",
-      "external_references": [{
-         "source_name": "job-tracker",
-         "id": "job-id-1234"
-      }],
-      "abstract": "Tracking Team Note#1",
-      "content": "This note indicates the various steps taken by the threat analyst team to investigate this specific campaign. Step 1) Do a scan 2) Review scanned results for identified hosts not known by external intel…etc.",
-      "authors": [
-         "John Doe"
-      ],
-      "object_refs": [
-         "campaign--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f"
-      ]
-   },
-   {
-      "type": "observed-data",
-      "spec_version": "2.1",
-      "id": "observed-data--b67d30ff-02ac-498a-92f9-32f845f448cf",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "created": "2016-04-06T19:58:16.000Z",
-      "modified": "2016-04-06T19:58:16.000Z",
-      "first_observed": "2015-12-21T19:00:00Z",
-      "last_observed": "2015-12-21T19:00:00Z",
-      "number_observed": 50,
-      "object_refs": [
-         "ipv4-address--efcd5e80-570d-4131-b213-62cb18eaa6a8",
-         "domain-name--ecb120bf-2694-4902-a737-62b74539a41b"
-      ]
-   }, {
-      "type": "domain-name",
-      "spec_version": "2.1",
-      "id": "domain-name--ecb120bf-2694-4902-a737-62b74539a41b",
-      "value": "example.com",
-      "resolves_to_refs": [
-         "ipv4-addr--efcd5e80-570d-4131-b213-62cb18eaa6a8"
-      ]
-   }, {
-      "type": "ipv4-addr",
-      "spec_version": "2.1",
-      "id": "ipv4-addr--efcd5e80-570d-4131-b213-62cb18eaa6a8",
-      "value": "198.51.100.3"
-   },
-   {
-      "type": "opinion",
-      "spec_version": "2.1",
-      "id": "opinion--b01efc25-77b4-4003-b18b-f6e24b5cd9f7",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "created": "2016-05-12T08:17:27.000Z",
-      "modified": "2016-05-12T08:17:27.000Z",
-      "object_refs": [
-         "relationship--16d2358f-3b0d-4c88-b047-0da2f7ed4471"
-      ],
-      "opinion": "strongly-disagree",
-      "explanation": "This doesn't seem like it is feasible. We've seen how PandaCat has attacked Spanish infrastructure over the last 3 years, so this change in targeting seems too great to be viable. The methods used are more commonly associated with the FlameDragonCrew."
-   },
-   {
-      "type": "report",
-      "spec_version": "2.1",
-      "id": "report--84e4d88f-44ea-4bcd-bbf3-b2c1c320bcb3",
-      "created_by_ref": "identity--a463ffb3-1bd9-4d94-b02d-74e4f1658283",
-      "created": "2015-12-21T19:59:11.000Z",
-      "modified": "2015-12-21T19:59:11.000Z",
-      "name": "The Black Vine Cyberespionage Group",
-      "description": "A simple report with an indicator and campaign",
-      "published": "2016-01-20T17:00:00.000Z",
-      "report_types": [
-         "campaign"
-      ],
-      "object_refs": [
-         "indicator--26ffb872-1dd9-446e-b6f5-d58527e5b5d2",
-         "campaign--83422c77-904c-4dc1-aff5-5c38f3a2c55c",
-         "relationship--f82356ae-fe6c-437c-9c24-6b64314ae68a"
-      ]
-   },
-   {
-      "type": "threat-actor",
-      "spec_version": "2.1",
-      "id": "threat-actor--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "created": "2016-04-06T20:03:48.000Z",
-      "modified": "2016-04-06T20:03:48.000Z",
-      "threat_actor_types": [
-         "crime-syndicate"
-      ],
-      "name": "Evil Org",
-      "description": "The Evil Org threat actor group",
-      "aliases": [
-         "Syndicate 1",
-         "Evil Syndicate 99"
-      ],
-      "roles": ["director"],
-      "goals": [
-         "Steal bank money",
-         "Steal credit cards"
-      ],
-      "sophistication": "advanced",
-      "resource_level": "team",
-      "primary_motivation": "organizational-gain"
-   },
-   {
-      "type": "tool",
-      "spec_version": "2.1",
-      "id": "tool--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "created": "2016-04-06T20:03:48.000Z",
-      "modified": "2016-04-06T20:03:48.000Z",
-      "tool_types": [
-         "remote-access"
-      ],
-      "name": "VNC"
-   },
-   {
-      "type": "vulnerability",
-      "spec_version": "2.1",
-      "id": "vulnerability--0c7b5b88-8ff7-4a4d-aa9d-feb398cd0061",
-      "created": "2016-05-12T08:17:27.000Z",
-      "modified": "2016-05-12T08:17:27.000Z",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "name": "CVE-2016-1234",
-      "external_references": [{
-         "source_name": "cve",
-         "external_id": "CVE-2016-1234"
-      }]
-   },
-   {
-      "type": "sighting",
-      "spec_version": "2.1",
-      "id": "sighting--ee20065d-2555-424f-ad9e-0f8428623c75",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "created": "2016-04-06T20:08:31.000Z",
-      "modified": "2016-04-06T20:08:31.000Z",
-      "first_seen": "2015-12-21T19:00:00Z",
-      "last_seen": "2015-12-21T19:00:00Z",
-      "count": 50,
-      "sighting_of_ref": "indicator--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
-      "observed_data_refs": [
-         "observed-data--b67d30ff-02ac-498a-92f9-32f845f448cf"
-      ],
-      "where_sighted_refs": [
-         "identity--b67d30ff-02ac-498a-92f9-32f845f448ff"
-      ]
-   },
-   {
-      "type": "observed-data",
-      "spec_version": "2.1",
-      "id": "observed-data--b67d30ff-02ac-498a-92f9-32f845f448cf",
-      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-      "created": "2016-04-06T19:58:16.000Z",
-      "modified": "2016-04-06T19:58:16.000Z",
-      "first_observed": "2015-12-21T19:00:00Z",
-      "last_observed": "2016-04-06T19:58:16Z",
-      "number_observed": 50,
-      "object_refs": [
-         "file--30038539-3eb6-44bc-a59e-d0d3fe84695a"
-      ]
-   },
-   {
-      "type": "artifact",
-      "spec_version": "2.1",
-      "id": "artifact--ca17bcf8-9846-5ab4-8662-75c1bf6e63ee",
-      "mime_type": "image/jpeg",
-      "payload_bin": "VBORw0KGgoAAAANSUhEUgAAADI=="
-   },
-   {
-      "type": "autonomous-system",
-      "spec_version": "2.1",
-      "id": "autonomous-system--f720c34b-98ae-597f-ade5-27dc241e8c74",
-      "number": 15139,
-      "name": "Slime Industries",
-      "rir": "ARIN"
-   },
-   {
-      "type": "directory",
-      "spec_version": "2.1",
-      "id": "directory--93c0a9b0-520d-545d-9094-1a08ddf46b05",
-      "path": "C:\\Windows\\System32"
-   },
-   {
-      "type": "domain-name",
-      "spec_version": "2.1",
-      "id": "domain-name--3c10e93f-798e-5a26-a0c1-08156efab7f5",
-      "value": "example.com"
-   },
-   {
-      "type": "email-addr",
-      "spec_version": "2.1",
-      "id": "email-addr--2d77a846-6264-5d51-b586-e43822ea1ea3",
-      "value": "john@example.com",
-      "display_name": "John Doe"
-   },
-   {
-      "type": "email-message",
-      "spec_version": "2.1",
-      "id": "email-message--cf9b4b7f-14c8-5955-8065-020e0316b559",
-      "is_multipart": true,
-      "received_lines": [
-         "from mail.example.com ([198.51.100.3]) by smtp.gmail.com with ESMTPSA id q23sm23309939wme.17.2016.07.19.07.20.32 (version=TLS1_2 cipher=ECDHE-RSA-AES128-GCM-SHA256 bits=128/128); Tue, 19 Jul 2016 07:20:40 -0700 (PDT)"
-      ],
-      "content_type": "multipart/mixed",
-      "date": "2016-06-19T14:20:40.000Z",
-      "from_ref": "email-addr--89f52ea8-d6ef-51e9-8fce-6a29236436ed",
-      "to_refs": [
-         "email-addr--d1b3bf0c-f02a-51a1-8102-11aba7959868"
-      ],
-      "cc_refs": [
-         "email-addr--e4ee5301-b52d-59cd-a8fa-8036738c7194"
-      ],
-      "subject": "Check out this picture of a cat!",
-      "additional_header_fields": {
-         "Content-Disposition": ["inline"],
-         "X-Mailer": ["Mutt/1.5.23"],
-         "X-Originating-IP": ["198.51.100.3"]
+    ]
+  },
+  {
+    "type": "relationship",
+    "spec_version": "2.1",
+    "id": "relationship--57b56a43-b8b0-4cba-9deb-34e3e1faed9e",
+    "created": "2016-05-12T08:17:27.000Z",
+    "modified": "2016-05-12T08:17:27.000Z",
+    "relationship_type": "uses",
+    "source_ref": "intrusion-set--0c7e22ad-b099-4dc3-b0df-2ea3f49ae2e6",
+    "target_ref": "attack-pattern--7e33a43e-e34b-40ec-89da-36c9bb2cacd5"
+  },
+  {
+    "type": "intrusion-set",
+    "spec_version": "2.1",
+    "id": "intrusion-set--0c7e22ad-b099-4dc3-b0df-2ea3f49ae2e6",
+    "created": "2016-05-12T08:17:27.000Z",
+    "modified": "2016-05-12T08:17:27.000Z",
+    "name": "Adversary X"
+  },
+  {
+    "type": "campaign",
+    "spec_version": "2.1",
+    "id": "campaign--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "created": "2016-04-06T20:03:00.000Z",
+    "modified": "2016-04-06T20:03:00.000Z",
+    "name": "Green Group Attacks Against Finance",
+    "description": "Campaign by Green Group against a series of targets in the financial services sector."
+  },
+  {
+    "type": "course-of-action",
+    "spec_version": "2.1",
+    "id": "course-of-action--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "created": "2016-04-06T20:03:48.000Z",
+    "modified": "2016-04-06T20:03:48.000Z",
+    "name": "mitigation-poison-ivy-firewall",
+    "description": "This action points to a recommended set of steps to respond to the Poison Ivy malware on a Cisco firewall device",
+    "action_type": "cisco:ios",
+    "action_reference": {
+      "source_name": "internet",
+      "url": "hxxps://www.stopthebad.com/poisonivyresponse.asa"
+    }
+  },
+  {
+    "type": "relationship",
+    "spec_version": "2.1",
+    "id": "relationship--44298a74-ba52-4f0c-87a3-1824e67d7fad",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "created": "2016-04-06T20:07:10.000Z",
+    "modified": "2016-04-06T20:07:10.000Z",
+    "relationship_type": "mitigates",
+    "source_ref": "course-of-action--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
+    "target_ref": "malware--31b940d4-6f7f-459a-80ea-9c1f17b5891b"
+  },
+  {
+    "type": "malware",
+    "spec_version": "2.1",
+    "id": "malware--31b940d4-6f7f-459a-80ea-9c1f17b5891b",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "created": "2016-04-06T20:07:09.000Z",
+    "modified": "2016-04-06T20:07:09.000Z",
+    "name": "Poison Ivy",
+    "malware_types": ["trojan"]
+  },
+  {
+    "type": "grouping",
+    "spec_version": "2.1",
+    "id": "grouping--84e4d88f-44ea-4bcd-bbf3-b2c1c320bcb3",
+    "created_by_ref": "identity--a463ffb3-1bd9-4d94-b02d-74e4f1658283",
+    "created": "2015-12-21T19:59:11.000Z",
+    "modified": "2015-12-21T19:59:11.000Z",
+    "name": "The Black Vine Cyberespionage Group",
+    "description": "A simple collection of Black Vine Cyberespionage Group attributed intel",
+    "context": "suspicious-activity",
+    "object_refs": [
+      "indicator--26ffb872-1dd9-446e-b6f5-d58527e5b5d2",
+      "campaign--83422c77-904c-4dc1-aff5-5c38f3a2c55c",
+      "relationship--f82356ae-fe6c-437c-9c24-6b64314ae68a",
+      "file--0203b5c8-f8b6-4ddb-9ad0-527d727f968b"
+    ]
+  },
+  {
+    "type": "identity",
+    "spec_version": "2.1",
+    "id": "identity--e5f1b90a-d9b6-40ab-81a9-8a29df4b6b65",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "created": "2016-04-06T20:03:00.000Z",
+    "modified": "2016-04-06T20:03:00.000Z",
+    "name": "ACME Widget, Inc.",
+    "identity_class": "organization"
+  },
+  {
+    "type": "indicator",
+    "spec_version": "2.1",
+    "id": "indicator--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "created": "2016-04-06T20:03:48.000Z",
+    "modified": "2016-04-06T20:03:48.000Z",
+    "indicator_types": ["malicious-activity"],
+    "name": "Poison Ivy Malware",
+    "description": "This file is part of Poison Ivy",
+    "pattern": "[ file:hashes.'SHA-256' = '4bac27393bdd9777ce02453256c5577cd02275510b2227f473d03f533924f877' ]",
+    "pattern_type": "stix",
+    "valid_from": "2016-01-01T00:00:00Z"
+  },
+  {
+    "type": "relationship",
+    "spec_version": "2.1",
+    "id": "relationship--44298a74-ba52-4f0c-87a3-1824e67d7fad",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "created": "2016-04-06T20:06:37.000Z",
+    "modified": "2016-04-06T20:06:37.000Z",
+    "relationship_type": "indicates",
+    "source_ref": "indicator--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
+    "target_ref": "malware--31b940d4-6f7f-459a-80ea-9c1f17b5891b"
+  },
+  {
+    "type": "malware",
+    "spec_version": "2.1",
+    "id": "malware--31b940d4-6f7f-459a-80ea-9c1f17b5891b",
+    "created": "2016-04-06T20:07:09.000Z",
+    "modified": "2016-04-06T20:07:09.000Z",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "name": "Poison Ivy",
+    "malware_types": ["trojan"]
+  },
+  {
+    "type": "infrastructure",
+    "spec_version": "2.1",
+    "id": "infrastructure--38c47d93-d984-4fd9-b87b-d69d0841628d",
+    "created": "2016-05-07T11:22:30.000Z",
+    "modified": "2016-05-07T11:22:30.000Z",
+    "name": "Poison Ivy C2",
+    "infrastructure_types": ["command-and-control"]
+  },
+  {
+    "type": "relationship",
+    "spec_version": "2.1",
+    "id": "relationship--7aebe2f0-28d6-48a2-9c3e-b0aaa60266ed",
+    "created": "2016-05-09T08:17:27.000Z",
+    "modified": "2016-05-09T08:17:27.000Z",
+    "relationship_type": "controls",
+    "source_ref": "infrastructure--38c47d93-d984-4fd9-b87b-d69d0841628d",
+    "target_ref": "malware--16f4f3f9-1b68-4abb-bb66-7639d49f1e30"
+  },
+  {
+    "type": "malware",
+    "spec_version": "2.1",
+    "id": "malware--16f4f3f9-1b68-4abb-bb66-7639d49f1e30",
+    "created": "2016-05-08T14:31:09.000Z",
+    "modified": "2016-05-08T14:31:09.000Z",
+    "is_family": true,
+    "malware_types": ["remote-access-trojan"],
+    "name": "Poison Ivy"
+  },
+  {
+    "type": "relationship",
+    "spec_version": "2.1",
+    "id": "relationship--7aebe2f0-28d6-48a2-9c3e-b0aaa60266ef",
+    "created": "2016-05-09T08:17:27.000Z",
+    "modified": "2016-05-09T08:17:27.000Z",
+    "relationship_type": "consists-of",
+    "source_ref": "infrastructure--38c47d93-d984-4fd9-b87b-d69d0841628d",
+    "target_ref": "ipv4-addr--b4e29b62-2053-47c4-bab4-bbce39e5ed67"
+  },
+  {
+    "type": "relationship",
+    "spec_version": "2.1",
+    "id": "relationship--7aebe2f0-28d6-48a2-9c3e-b0aaa60266ef",
+    "created": "2016-05-09T08:17:27.000Z",
+    "modified": "2016-05-09T08:17:27.000Z",
+    "relationship_type": "consists-of",
+    "source_ref": "infrastructure--38c47d93-d984-4fd9-b87b-d69d0841628d",
+    "target_ref": "ipv4-addr--84445275-e371-444b-baea-ac7d07a180fd"
+  },
+  {
+    "type": "ipv4-addr",
+    "spec_version": "2.1",
+    "id": "ipv4-addr--b4e29b62-2053-47c4-bab4-bbce39e5ed67",
+    "value": "198.51.100.3"
+  },
+  {
+    "type": "ipv4-addr",
+    "spec_version": "2.1",
+    "id": "ipv4-addr--84445275-e371-444b-baea-ac7d07a180fd",
+    "value": "198.52.200.4"
+  },
+  {
+    "type": "intrusion-set",
+    "spec_version": "2.1",
+    "id": "intrusion-set--4e78f46f-a023-4e5f-bc24-71b3ca22ec29",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "created": "2016-04-06T20:03:48.000Z",
+    "modified": "2016-04-06T20:03:48.000Z",
+    "name": "Bobcat Breakin",
+    "description": "Incidents usually feature a shared TTP of a bobcat being released within the building containing network access, scaring users to leave their computers without locking them first. Still determining where the threat actors are getting the bobcats.",
+    "aliases": ["Zookeeper"],
+    "goals": ["acquisition-theft", "harassment", "damage"]
+  },
+  {
+    "type": "location",
+    "spec_version": "2.1",
+    "id": "location--a6e9345f-5a15-4c29-8bb3-7dcc5d168d64",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "created": "2016-04-06T20:03:00.000Z",
+    "modified": "2016-04-06T20:03:00.000Z",
+    "region": "south-eastern-asia",
+    "country": "th",
+    "administrative_area": "Tak",
+    "postal_code": "63170"
+  },
+  {
+    "type": "note",
+    "spec_version": "2.1",
+    "id": "note--0c7b5b88-8ff7-4a4d-aa9d-feb398cd0061",
+    "created": "2016-05-12T08:17:27.000Z",
+    "modified": "2016-05-12T08:17:27.000Z",
+    "external_references": [
+      {
+        "source_name": "job-tracker",
+        "id": "job-id-1234"
+      }
+    ],
+    "abstract": "Tracking Team Note#1",
+    "content": "This note indicates the various steps taken by the threat analyst team to investigate this specific campaign. Step 1) Do a scan 2) Review scanned results for identified hosts not known by external intel…etc.",
+    "authors": ["John Doe"],
+    "object_refs": ["campaign--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f"]
+  },
+  {
+    "type": "observed-data",
+    "spec_version": "2.1",
+    "id": "observed-data--b67d30ff-02ac-498a-92f9-32f845f448cf",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "created": "2016-04-06T19:58:16.000Z",
+    "modified": "2016-04-06T19:58:16.000Z",
+    "first_observed": "2015-12-21T19:00:00Z",
+    "last_observed": "2015-12-21T19:00:00Z",
+    "number_observed": 50,
+    "object_refs": [
+      "ipv4-address--efcd5e80-570d-4131-b213-62cb18eaa6a8",
+      "domain-name--ecb120bf-2694-4902-a737-62b74539a41b"
+    ]
+  },
+  {
+    "type": "domain-name",
+    "spec_version": "2.1",
+    "id": "domain-name--ecb120bf-2694-4902-a737-62b74539a41b",
+    "value": "example.com",
+    "resolves_to_refs": ["ipv4-addr--efcd5e80-570d-4131-b213-62cb18eaa6a8"]
+  },
+  {
+    "type": "ipv4-addr",
+    "spec_version": "2.1",
+    "id": "ipv4-addr--efcd5e80-570d-4131-b213-62cb18eaa6a8",
+    "value": "198.51.100.3"
+  },
+  {
+    "type": "opinion",
+    "spec_version": "2.1",
+    "id": "opinion--b01efc25-77b4-4003-b18b-f6e24b5cd9f7",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "created": "2016-05-12T08:17:27.000Z",
+    "modified": "2016-05-12T08:17:27.000Z",
+    "object_refs": ["relationship--16d2358f-3b0d-4c88-b047-0da2f7ed4471"],
+    "opinion": "strongly-disagree",
+    "explanation": "This doesn't seem like it is feasible. We've seen how PandaCat has attacked Spanish infrastructure over the last 3 years, so this change in targeting seems too great to be viable. The methods used are more commonly associated with the FlameDragonCrew."
+  },
+  {
+    "type": "report",
+    "spec_version": "2.1",
+    "id": "report--84e4d88f-44ea-4bcd-bbf3-b2c1c320bcb3",
+    "created_by_ref": "identity--a463ffb3-1bd9-4d94-b02d-74e4f1658283",
+    "created": "2015-12-21T19:59:11.000Z",
+    "modified": "2015-12-21T19:59:11.000Z",
+    "name": "The Black Vine Cyberespionage Group",
+    "description": "A simple report with an indicator and campaign",
+    "published": "2016-01-20T17:00:00.000Z",
+    "report_types": ["campaign"],
+    "object_refs": [
+      "indicator--26ffb872-1dd9-446e-b6f5-d58527e5b5d2",
+      "campaign--83422c77-904c-4dc1-aff5-5c38f3a2c55c",
+      "relationship--f82356ae-fe6c-437c-9c24-6b64314ae68a"
+    ]
+  },
+  {
+    "type": "threat-actor",
+    "spec_version": "2.1",
+    "id": "threat-actor--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "created": "2016-04-06T20:03:48.000Z",
+    "modified": "2016-04-06T20:03:48.000Z",
+    "threat_actor_types": ["crime-syndicate"],
+    "name": "Evil Org",
+    "description": "The Evil Org threat actor group",
+    "aliases": ["Syndicate 1", "Evil Syndicate 99"],
+    "roles": ["director"],
+    "goals": ["Steal bank money", "Steal credit cards"],
+    "sophistication": "advanced",
+    "resource_level": "team",
+    "primary_motivation": "organizational-gain"
+  },
+  {
+    "type": "tool",
+    "spec_version": "2.1",
+    "id": "tool--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "created": "2016-04-06T20:03:48.000Z",
+    "modified": "2016-04-06T20:03:48.000Z",
+    "tool_types": ["remote-access"],
+    "name": "VNC"
+  },
+  {
+    "type": "vulnerability",
+    "spec_version": "2.1",
+    "id": "vulnerability--0c7b5b88-8ff7-4a4d-aa9d-feb398cd0061",
+    "created": "2016-05-12T08:17:27.000Z",
+    "modified": "2016-05-12T08:17:27.000Z",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "name": "CVE-2016-1234",
+    "external_references": [
+      {
+        "source_name": "cve",
+        "external_id": "CVE-2016-1234"
+      }
+    ]
+  },
+  {
+    "type": "sighting",
+    "spec_version": "2.1",
+    "id": "sighting--ee20065d-2555-424f-ad9e-0f8428623c75",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "created": "2016-04-06T20:08:31.000Z",
+    "modified": "2016-04-06T20:08:31.000Z",
+    "first_seen": "2015-12-21T19:00:00Z",
+    "last_seen": "2015-12-21T19:00:00Z",
+    "count": 50,
+    "sighting_of_ref": "indicator--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
+    "observed_data_refs": [
+      "observed-data--b67d30ff-02ac-498a-92f9-32f845f448cf"
+    ],
+    "where_sighted_refs": ["identity--b67d30ff-02ac-498a-92f9-32f845f448ff"]
+  },
+  {
+    "type": "observed-data",
+    "spec_version": "2.1",
+    "id": "observed-data--b67d30ff-02ac-498a-92f9-32f845f448cf",
+    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+    "created": "2016-04-06T19:58:16.000Z",
+    "modified": "2016-04-06T19:58:16.000Z",
+    "first_observed": "2015-12-21T19:00:00Z",
+    "last_observed": "2016-04-06T19:58:16Z",
+    "number_observed": 50,
+    "object_refs": ["file--30038539-3eb6-44bc-a59e-d0d3fe84695a"]
+  },
+  {
+    "type": "artifact",
+    "spec_version": "2.1",
+    "id": "artifact--ca17bcf8-9846-5ab4-8662-75c1bf6e63ee",
+    "mime_type": "image/jpeg",
+    "payload_bin": "VBORw0KGgoAAAANSUhEUgAAADI=="
+  },
+  {
+    "type": "autonomous-system",
+    "spec_version": "2.1",
+    "id": "autonomous-system--f720c34b-98ae-597f-ade5-27dc241e8c74",
+    "number": 15139,
+    "name": "Slime Industries",
+    "rir": "ARIN"
+  },
+  {
+    "type": "directory",
+    "spec_version": "2.1",
+    "id": "directory--93c0a9b0-520d-545d-9094-1a08ddf46b05",
+    "path": "C:\\Windows\\System32"
+  },
+  {
+    "type": "domain-name",
+    "spec_version": "2.1",
+    "id": "domain-name--3c10e93f-798e-5a26-a0c1-08156efab7f5",
+    "value": "example.com"
+  },
+  {
+    "type": "email-addr",
+    "spec_version": "2.1",
+    "id": "email-addr--2d77a846-6264-5d51-b586-e43822ea1ea3",
+    "value": "john@example.com",
+    "display_name": "John Doe"
+  },
+  {
+    "type": "email-message",
+    "spec_version": "2.1",
+    "id": "email-message--cf9b4b7f-14c8-5955-8065-020e0316b559",
+    "is_multipart": true,
+    "received_lines": [
+      "from mail.example.com ([198.51.100.3]) by smtp.gmail.com with ESMTPSA id q23sm23309939wme.17.2016.07.19.07.20.32 (version=TLS1_2 cipher=ECDHE-RSA-AES128-GCM-SHA256 bits=128/128); Tue, 19 Jul 2016 07:20:40 -0700 (PDT)"
+    ],
+    "content_type": "multipart/mixed",
+    "date": "2016-06-19T14:20:40.000Z",
+    "from_ref": "email-addr--89f52ea8-d6ef-51e9-8fce-6a29236436ed",
+    "to_refs": ["email-addr--d1b3bf0c-f02a-51a1-8102-11aba7959868"],
+    "cc_refs": ["email-addr--e4ee5301-b52d-59cd-a8fa-8036738c7194"],
+    "subject": "Check out this picture of a cat!",
+    "additional_header_fields": {
+      "Content-Disposition": ["inline"],
+      "X-Mailer": ["Mutt/1.5.23"],
+      "X-Originating-IP": ["198.51.100.3"]
+    },
+    "body_multipart": [
+      {
+        "content_type": "text/plain; charset=utf-8",
+        "content_disposition": "inline",
+        "body": "Cats are funny!"
       },
-      "body_multipart": [{
-            "content_type": "text/plain; charset=utf-8",
-            "content_disposition": "inline",
-            "body": "Cats are funny!"
-         },
-         {
-            "content_type": "image/png",
-            "content_disposition": "attachment; filename=\"tabby.png\"",
-            "body_raw_ref": "artifact--4cce66f8-6eaa-53cb-85d5-3a85fca3a6c5"
-         },
-         {
-            "content_type": "application/zip",
-            "content_disposition": "attachment; filename=\"tabby_pics.zip\"",
-            "body_raw_ref": "file--6ce09d9c-0ad3-5ebf-900c-e3cb288955b5"
-         }
-      ]
-   }, {
-      "type": "email-addr",
-      "spec_version": "2.1",
-      "id": "email-addr--89f52ea8-d6ef-51e9-8fce-6a29236436ed",
-      "value": "jdoe@example.com",
-      "display_name": "John Doe"
-   }, {
-      "type": "email-addr",
-      "spec_version": "2.1",
-      "id": "email-addr--d1b3bf0c-f02a-51a1-8102-11aba7959868",
-      "value": "bob@example.com",
-      "display_name": "Bob Smith"
-   }, {
-      "type": "email-addr",
-      "spec_version": "2.1",
-      "id": "email-addr--e4ee5301-b52d-59cd-a8fa-8036738c7194",
-      "value": "mary@example.com",
-      "display_name": "Mary Smith"
-   }, {
-      "type": "artifact",
-      "spec_version": "2.1",
-      "id": "artifact--4cce66f8-6eaa-53cb-85d5-3a85fca3a6c5",
-      "mime_type": "image/jpeg",
-      "payload_bin": "VBORw0KGgoAAAANSUhEUgAAADI==",
-      "hashes": {
-         "SHA-256": "effb46bba03f6c8aea5c653f9cf984f170dcdd3bbbe2ff6843c3e5da0e698766"
+      {
+        "content_type": "image/png",
+        "content_disposition": "attachment; filename=\"tabby.png\"",
+        "body_raw_ref": "artifact--4cce66f8-6eaa-53cb-85d5-3a85fca3a6c5"
+      },
+      {
+        "content_type": "application/zip",
+        "content_disposition": "attachment; filename=\"tabby_pics.zip\"",
+        "body_raw_ref": "file--6ce09d9c-0ad3-5ebf-900c-e3cb288955b5"
       }
-   }, {
-      "type": "file",
-      "spec_version": "2.1",
-      "id": "file--6ce09d9c-0ad3-5ebf-900c-e3cb288955b5",
-      "name": "tabby_pics.zip",
-      "magic_number_hex": "504B0304",
-      "hashes": {
-         "SHA-256": "fe90a7e910cb3a4739bed9180e807e93fa70c90f25a8915476f5e4bfbac681db"
+    ]
+  },
+  {
+    "type": "email-addr",
+    "spec_version": "2.1",
+    "id": "email-addr--89f52ea8-d6ef-51e9-8fce-6a29236436ed",
+    "value": "jdoe@example.com",
+    "display_name": "John Doe"
+  },
+  {
+    "type": "email-addr",
+    "spec_version": "2.1",
+    "id": "email-addr--d1b3bf0c-f02a-51a1-8102-11aba7959868",
+    "value": "bob@example.com",
+    "display_name": "Bob Smith"
+  },
+  {
+    "type": "email-addr",
+    "spec_version": "2.1",
+    "id": "email-addr--e4ee5301-b52d-59cd-a8fa-8036738c7194",
+    "value": "mary@example.com",
+    "display_name": "Mary Smith"
+  },
+  {
+    "type": "artifact",
+    "spec_version": "2.1",
+    "id": "artifact--4cce66f8-6eaa-53cb-85d5-3a85fca3a6c5",
+    "mime_type": "image/jpeg",
+    "payload_bin": "VBORw0KGgoAAAANSUhEUgAAADI==",
+    "hashes": {
+      "SHA-256": "effb46bba03f6c8aea5c653f9cf984f170dcdd3bbbe2ff6843c3e5da0e698766"
+    }
+  },
+  {
+    "type": "file",
+    "spec_version": "2.1",
+    "id": "file--6ce09d9c-0ad3-5ebf-900c-e3cb288955b5",
+    "name": "tabby_pics.zip",
+    "magic_number_hex": "504B0304",
+    "hashes": {
+      "SHA-256": "fe90a7e910cb3a4739bed9180e807e93fa70c90f25a8915476f5e4bfbac681db"
+    }
+  },
+  {
+    "type": "ipv6-addr",
+    "spec_version": "2.1",
+    "id": "ipv6-addr--1e61d36c-a16c-53b7-a80f-2a00161c96b1",
+    "value": "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+  },
+  {
+    "type": "mac-addr",
+    "spec_version": "2.1",
+    "id": "mac-addr--65cfcf98-8a6e-5a1b-8f61-379ac4f92d00",
+    "value": "d2:fb:49:24:37:18"
+  },
+  {
+    "type": "mutex",
+    "spec_version": "2.1",
+    "id": "mutex--eba44954-d4e4-5d3b-814c-2b17dd8de300",
+    "name": "__CLEANSWEEP__"
+  },
+  {
+    "type": "ipv4-addr",
+    "spec_version": "2.1",
+    "id": "ipv4-addr--4d22aae0-2bf9-5427-8819-e4f6abf20a53",
+    "value": "198.51.100.2"
+  },
+  {
+    "type": "ipv4-addr",
+    "spec_version": "2.1",
+    "id": "ipv4-addr--ff26c055-6336-5bc5-b98d-13d6226742dd",
+    "value": "198.51.100.3"
+  },
+  {
+    "type": "network-traffic",
+    "spec_version": "2.1",
+    "id": "network-traffic--2568d22a-8998-58eb-99ec-3c8ca74f527d",
+    "src_ref": "ipv4-addr--4d22aae0-2bf9-5427-8819-e4f6abf20a53",
+    "dst_ref": "ipv4-addr--ff26c055-6336-5bc5-b98d-13d6226742dd",
+    "protocols": ["tcp"]
+  },
+  {
+    "type": "process",
+    "spec_version": "2.1",
+    "id": "process--f52a906a-0dfc-40bd-92f1-e7778ead38a9",
+    "pid": 1221,
+    "created": "2016-01-20T14:11:25.55Z",
+    "command_line": "./gedit-bin --new-window",
+    "image_ref": "file--e04f22d1-be2c-59de-add8-10f61d15fe20"
+  },
+  {
+    "type": "software",
+    "spec_version": "2.1",
+    "id": "software--a1827f6d-ca53-5605-9e93-4316cd22a00a",
+    "name": "Word",
+    "cpe": "cpe:2.3:a:microsoft:word:2000:*:*:*:*:*:*:*",
+    "version": "2002",
+    "vendor": "Microsoft"
+  },
+  {
+    "type": "url",
+    "spec_version": "2.1",
+    "id": "url--c1477287-23ac-5971-a010-5c287877fa60",
+    "value": "https://example.com/research/index.html"
+  },
+  {
+    "type": "user-account",
+    "spec_version": "2.1",
+    "id": "user-account--0d5b424b-93b8-5cd8-ac36-306e1789d63c",
+    "user_id": "1001",
+    "account_login": "jdoe",
+    "account_type": "unix",
+    "display_name": "John Doe",
+    "is_service_account": false,
+    "is_privileged": false,
+    "can_escalate_privs": true,
+    "account_created": "2016-01-20T12:31:12Z",
+    "credential_last_changed": "2016-01-20T14:27:43Z",
+    "account_first_login": "2016-01-20T14:26:07Z",
+    "account_last_login": "2016-07-22T16:08:28Z"
+  },
+  {
+    "type": "windows-registry-key",
+    "spec_version": "2.1",
+    "id": "windows-registry-key--2ba37ae7-2745-5082-9dfd-9486dad41016",
+    "key": "hkey_local_machine\\system\\bar\\foo",
+    "values": [
+      {
+        "name": "Foo",
+        "data": "qwerty",
+        "data_type": "REG_SZ"
+      },
+      {
+        "name": "Bar",
+        "data": "42",
+        "data_type": "REG_DWORD"
       }
-   },
-   {
-      "type": "ipv6-addr",
-      "spec_version": "2.1",
-      "id": "ipv6-addr--1e61d36c-a16c-53b7-a80f-2a00161c96b1",
-      "value": "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
-   },
-   {
-      "type": "mac-addr",
-      "spec_version": "2.1",
-      "id": "mac-addr--65cfcf98-8a6e-5a1b-8f61-379ac4f92d00",
-      "value": "d2:fb:49:24:37:18"
-   },
-   {
-      "type": "mutex",
-      "spec_version": "2.1",
-      "id": "mutex--eba44954-d4e4-5d3b-814c-2b17dd8de300",
-      "name": "__CLEANSWEEP__"
-   },
-   {
-      "type": "ipv4-addr",
-      "spec_version": "2.1",
-      "id": "ipv4-addr--4d22aae0-2bf9-5427-8819-e4f6abf20a53",
-      "value": "198.51.100.2"
-   }, {
-      "type": "ipv4-addr",
-      "spec_version": "2.1",
-      "id": "ipv4-addr--ff26c055-6336-5bc5-b98d-13d6226742dd",
-      "value": "198.51.100.3"
-   }, {
-      "type": "network-traffic",
-      "spec_version": "2.1",
-      "id": "network-traffic--2568d22a-8998-58eb-99ec-3c8ca74f527d",
-      "src_ref": "ipv4-addr--4d22aae0-2bf9-5427-8819-e4f6abf20a53",
-      "dst_ref": "ipv4-addr--ff26c055-6336-5bc5-b98d-13d6226742dd",
-      "protocols": [
-         "tcp"
-      ]
-   },
-   {
-      "type": "process",
-      "spec_version": "2.1",
-      "id": "process--f52a906a-0dfc-40bd-92f1-e7778ead38a9",
-      "pid": 1221,
-      "created": "2016-01-20T14:11:25.55Z",
-      "command_line": "./gedit-bin --new-window",
-      "image_ref": "file--e04f22d1-be2c-59de-add8-10f61d15fe20"
-   },
-   {
-      "type": "software",
-      "spec_version": "2.1",
-      "id": "software--a1827f6d-ca53-5605-9e93-4316cd22a00a",
-      "name": "Word",
-      "cpe": "cpe:2.3:a:microsoft:word:2000:*:*:*:*:*:*:*",
-      "version": "2002",
-      "vendor": "Microsoft"
-   },
-   {
-      "type": "url",
-      "spec_version": "2.1",
-      "id": "url--c1477287-23ac-5971-a010-5c287877fa60",
-      "value": "https://example.com/research/index.html"
-   },
-   {
-      "type": "user-account",
-      "spec_version": "2.1",
-      "id": "user-account--0d5b424b-93b8-5cd8-ac36-306e1789d63c",
-      "user_id": "1001",
-      "account_login": "jdoe",
-      "account_type": "unix",
-      "display_name": "John Doe",
-      "is_service_account": false,
-      "is_privileged": false,
-      "can_escalate_privs": true,
-      "account_created": "2016-01-20T12:31:12Z",
-      "credential_last_changed": "2016-01-20T14:27:43Z",
-      "account_first_login": "2016-01-20T14:26:07Z",
-      "account_last_login": "2016-07-22T16:08:28Z"
-   },
-   {
-      "type": "windows-registry-key",
-      "spec_version": "2.1",
-      "id": "windows-registry-key--2ba37ae7-2745-5082-9dfd-9486dad41016",
-      "key": "hkey_local_machine\\system\\bar\\foo",
-      "values": [{
-            "name": "Foo",
-            "data": "qwerty",
-            "data_type": "REG_SZ"
-         },
-         {
-            "name": "Bar",
-            "data": "42",
-            "data_type": "REG_DWORD"
-         }
-      ]
-   },
-   {
-      "type": "x509-certificate",
-      "spec_version": "2.1",
-      "id": "x509-certificate--b595eaf0-0b28-5dad-9e8e-0fab9c1facc9",
-      "issuer": "C=ZA, ST=Western Cape, L=Cape Town, O=Thawte Consulting cc, OU=Certification Services Division, CN=Thawte Server CA/emailAddress=server-certs@thawte.com",
-      "validity_not_before": "2016-03-12T12:00:00Z",
-      "validity_not_after": "2016-08-21T12:00:00Z",
-      "subject": "C=US, ST=Maryland, L=Pasadena, O=Brent Baccala, OU=FreeSoft, CN=www.freesoft.org/emailAddress=baccala@freesoft.org",
-      "serial_number": "02:08:87:83:f2:13:58:1f:79:52:1e:66:90:0a:02:24:c9:6b:c7:dc",
-      "x509_v3_extensions": {
-         "basic_constraints": "critical,CA:TRUE, pathlen:0",
-         "name_constraints": "permitted;IP:192.168.0.0/255.255.0.0",
-         "policy_contraints": "requireExplicitPolicy:3",
-         "key_usage": "critical, keyCertSign",
-         "extended_key_usage": "critical,codeSigning,1.2.3.4",
-         "subject_key_identifier": "hash",
-         "authority_key_identifier": "keyid,issuer",
-         "subject_alternative_name": "email:my@other.address,RID:1.2.3.4",
-         "issuer_alternative_name": "issuer:copy",
-         "crl_distribution_points": "URI:http://myhost.com/myca.crl",
-         "inhibit_any_policy": "2",
-         "private_key_usage_period_not_before": "2016-03-12T12:00:00Z",
-         "private_key_usage_period_not_after": "2018-03-12T12:00:00Z",
-         "certificate_policies": "1.2.4.5, 1.1.3.4"
+    ]
+  },
+  {
+    "type": "x509-certificate",
+    "spec_version": "2.1",
+    "id": "x509-certificate--b595eaf0-0b28-5dad-9e8e-0fab9c1facc9",
+    "issuer": "C=ZA, ST=Western Cape, L=Cape Town, O=Thawte Consulting cc, OU=Certification Services Division, CN=Thawte Server CA/emailAddress=server-certs@thawte.com",
+    "validity_not_before": "2016-03-12T12:00:00Z",
+    "validity_not_after": "2016-08-21T12:00:00Z",
+    "subject": "C=US, ST=Maryland, L=Pasadena, O=Brent Baccala, OU=FreeSoft, CN=www.freesoft.org/emailAddress=baccala@freesoft.org",
+    "serial_number": "02:08:87:83:f2:13:58:1f:79:52:1e:66:90:0a:02:24:c9:6b:c7:dc",
+    "x509_v3_extensions": {
+      "basic_constraints": "critical,CA:TRUE, pathlen:0",
+      "name_constraints": "permitted;IP:192.168.0.0/255.255.0.0",
+      "policy_contraints": "requireExplicitPolicy:3",
+      "key_usage": "critical, keyCertSign",
+      "extended_key_usage": "critical,codeSigning,1.2.3.4",
+      "subject_key_identifier": "hash",
+      "authority_key_identifier": "keyid,issuer",
+      "subject_alternative_name": "email:my@other.address,RID:1.2.3.4",
+      "issuer_alternative_name": "issuer:copy",
+      "crl_distribution_points": "URI:http://myhost.com/myca.crl",
+      "inhibit_any_policy": "2",
+      "private_key_usage_period_not_before": "2016-03-12T12:00:00Z",
+      "private_key_usage_period_not_after": "2018-03-12T12:00:00Z",
+      "certificate_policies": "1.2.4.5, 1.1.3.4"
+    }
+  },
+  {
+    "type": "campaign",
+    "id": "campaign--12a111f0-b824-4baf-a224-83b80237a094",
+    "lang": "en",
+    "spec_version": "2.1",
+    "created": "2017-02-08T21:31:22.007Z",
+    "modified": "2017-02-08T21:31:22.007Z",
+    "name": "Bank Attack",
+    "description": "More information about bank attack"
+  },
+  {
+    "type": "language-content",
+    "id": "language-content--b86bd89f-98bb-4fa9-8cb2-9ad421da981d",
+    "spec_version": "2.1",
+    "created": "2017-02-08T21:31:22.007Z",
+    "modified": "2017-02-08T21:31:22.007Z",
+    "object_ref": "campaign--12a111f0-b824-4baf-a224-83b80237a094",
+    "object_modified": "2017-02-08T21:31:22.007Z",
+    "contents": {
+      "de": {
+        "name": "Bank Angriff",
+        "description": "Weitere Informationen über Banküberfall"
+      },
+      "fr": {
+        "name": "Attaque Bank",
+        "description": "Plus d'informations sur la crise bancaire"
       }
-   },
-   {
-      "type": "campaign",
-      "id": "campaign--12a111f0-b824-4baf-a224-83b80237a094",
-      "lang": "en",
-      "spec_version": "2.1",
-      "created": "2017-02-08T21:31:22.007Z",
-      "modified": "2017-02-08T21:31:22.007Z",
-      "name": "Bank Attack",
-      "description": "More information about bank attack"
-   }, {
-      "type": "language-content",
-      "id": "language-content--b86bd89f-98bb-4fa9-8cb2-9ad421da981d",
-      "spec_version": "2.1",
-      "created": "2017-02-08T21:31:22.007Z",
-      "modified": "2017-02-08T21:31:22.007Z",
-      "object_ref": "campaign--12a111f0-b824-4baf-a224-83b80237a094",
-      "object_modified": "2017-02-08T21:31:22.007Z",
-      "contents": {
-         "de": {
-            "name": "Bank Angriff",
-            "description": "Weitere Informationen über Banküberfall"
-         },
-         "fr": {
-            "name": "Attaque Bank",
-            "description": "Plus d'informations sur la crise bancaire"
-         }
-      }
-   },
-   {
-      "type": "marking-definition",
-      "spec_version": "2.1",
-      "id": "marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da",
-      "created": "2016-08-01T00:00:00.000Z",
-      "definition_type": "statement",
-      "definition": {
-         "statement": "Copyright 2019, Example Corp"
-      }
-   },
-   {
-      "type": "malware-analysis",
-      "spec_version": "2.1",
-      "id": "malware-analysis--d0a5219b-4960-4b0c-a9ce-ed7b0552cc1b",
-      "av_result": "benign",
-      "created": "2016-08-02T00:00:00.000Z"
-   }
+    }
+  },
+  {
+    "type": "marking-definition",
+    "spec_version": "2.1",
+    "id": "marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da",
+    "created": "2016-08-01T00:00:00.000Z",
+    "definition_type": "statement",
+    "definition": {
+      "statement": "Copyright 2019, Example Corp"
+    }
+  },
+  {
+    "type": "malware-analysis",
+    "spec_version": "2.1",
+    "id": "malware-analysis--d0a5219b-4960-4b0c-a9ce-ed7b0552cc1b",
+    "av_result": "benign",
+    "created": "2016-08-02T00:00:00.000Z"
+  },
+  {
+    "id": "extension-definition--9c59fd79-4215-4ba2-920d-3e4f320e1e62",
+    "type": "extension-definition",
+    "spec_version": "2.1",
+    "name": "New SDO 1",
+    "description": "This schema creates a new object type called my-favorite-sdo-1",
+    "created": "2014-02-20T09:16:08.989000Z",
+    "modified": "2014-02-20T09:16:08.989000Z",
+    "created_by_ref": "identity--11b76a96-5d2b-45e0-8a5a-f6994f370731",
+    "schema": "https://www.example.com/schema-my-favorite-sdo-1/v1/",
+    "version": "1.2.1",
+    "extension_types": ["new-sdo"]
+  }
 ]

--- a/testresources/all.json
+++ b/testresources/all.json
@@ -695,5 +695,25 @@
         "toxicity": 8
       }
     }
+  },
+  {
+    "type": "indicator",
+    "spec_version": "2.1",
+    "id": "indicator--e97bfccf-8970-4a3c-9cd1-5b5b97ed5d0d",
+    "created": "2014-02-20T09:16:08.989000Z",
+    "modified": "2014-02-20T09:16:08.989000Z",
+    "name": "File hash for Poison Ivy variant",
+    "description": "This file hash indicates that a sample of Poison Ivy is present.",
+    "labels": ["malicious-activity"],
+    "pattern": "[file:hashes.'SHA-256' = 'ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c']",
+    "pattern_type": "stix",
+    "valid_from": "2014-02-20T09:00:00.000000Z",
+    "rank": 5,
+    "toxicity": 8,
+    "extensions": {
+      "extension-definition--d83fce45-ef58-4c6c-a3f4-1fbc32e98c6e": {
+        "extension_type": "toplevel-property-extension"
+      }
+    }
   }
 ]

--- a/testresources/all.json
+++ b/testresources/all.json
@@ -645,8 +645,10 @@
     "type": "malware-analysis",
     "spec_version": "2.1",
     "id": "malware-analysis--d0a5219b-4960-4b0c-a9ce-ed7b0552cc1b",
-    "av_result": "benign",
-    "created": "2016-08-02T00:00:00.000Z"
+    "result": "benign",
+    "created": "2016-08-02T00:00:00.000Z",
+    "modified": "2016-08-02T00:00:00.000Z",
+    "product": "some-av"
   },
   {
     "id": "extension-definition--9c59fd79-4215-4ba2-920d-3e4f320e1e62",

--- a/testresources/all.json
+++ b/testresources/all.json
@@ -660,5 +660,20 @@
     "schema": "https://www.example.com/schema-my-favorite-sdo-1/v1/",
     "version": "1.2.1",
     "extension_types": ["new-sdo"]
+  },
+  {
+    "type": "my-favorite-sdo",
+    "spec_version": "2.1",
+    "id": "my-favorite-sdo--ac97aae4-83f1-46ca-a351-7aeb76678189",
+    "created": "2014-02-20T09:16:08.989000Z",
+    "modified": "2014-02-20T09:16:08.989000Z",
+    "name": "This is the name of my favorite",
+    "some_property_name1": "value1",
+    "some_property_name2": "value2",
+    "extensions": {
+      "extension-definition--9c59fd79-4215-4ba2-920d-3e4f320e1e62": {
+        "extension_type": "new-sdo"
+      }
+    }
   }
 ]

--- a/testresources/all.json
+++ b/testresources/all.json
@@ -675,5 +675,25 @@
         "extension_type": "new-sdo"
       }
     }
+  },
+  {
+    "type": "indicator",
+    "spec_version": "2.1",
+    "id": "indicator--e97bfccf-8970-4a3c-9cd1-5b5b97ed5d0c",
+    "created": "2014-02-20T09:16:08.989000Z",
+    "modified": "2014-02-20T09:16:08.989000Z",
+    "name": "File hash for Poison Ivy variant",
+    "description": "This file hash indicates that a sample of Poison Ivy is present.",
+    "labels": ["malicious-activity"],
+    "pattern": "[file:hashes.'SHA-256' = 'ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c']",
+    "pattern_type": "stix",
+    "valid_from": "2014-02-20T09:00:00.000000Z",
+    "extensions": {
+      "extension-definition--d83fce45-ef58-4c6c-a3f4-1fbc32e98c6e": {
+        "extension_type": "property-extension",
+        "rank": 5,
+        "toxicity": 8
+      }
+    }
   }
 ]

--- a/threat-actor.go
+++ b/threat-actor.go
@@ -73,6 +73,10 @@ type ThreatActor struct {
 	PersonalMotivations []string `json:"personal_motivations,omitempty"`
 }
 
+func (o *ThreatActor) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // AddAttributedTo creates a relationship to the ThreatActor's real identity.
 func (a *ThreatActor) AddAttributedTo(id Identifier, opts ...STIXOption) (*Relationship, error) {
 	if !IsValidIdentifier(id) || !id.ForType(TypeIdentity) {

--- a/tool.go
+++ b/tool.go
@@ -39,6 +39,10 @@ type Tool struct {
 	Version string `json:"tool_version,omitempty"`
 }
 
+func (o *Tool) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // AddDelivers creates a relationship that describes that this Tool is used to
 // deliver a malware instance (or family).
 func (a *Tool) AddDelivers(id Identifier, opts ...STIXOption) (*Relationship, error) {

--- a/url.go
+++ b/url.go
@@ -26,6 +26,6 @@ func NewURL(value string, opts ...STIXOption) (*URL, error) {
 	}
 
 	err := applyOptions(obj, opts)
-	obj.ID = NewObservableIdenfier(fmt.Sprintf("[\"%s\"]", value), TypeURL)
+	obj.ID = NewObservableIdentifier(fmt.Sprintf("[\"%s\"]", value), TypeURL)
 	return obj, err
 }

--- a/url.go
+++ b/url.go
@@ -14,6 +14,10 @@ type URL struct {
 	Value string `json:"value"`
 }
 
+func (o *URL) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewURL creates a new URL object.
 func NewURL(value string, opts ...STIXOption) (*URL, error) {
 	if value == "" {

--- a/url_test.go
+++ b/url_test.go
@@ -37,7 +37,6 @@ func TestURL(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 		}
 		obj, err := NewURL(val, opts...)
 		assert.NotNil(obj)

--- a/user.go
+++ b/user.go
@@ -64,6 +64,10 @@ type UserAccount struct {
 	AccountLastLogin *Timestamp `json:"account_last_login,omitempty"`
 }
 
+func (o *UserAccount) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // UNIXAccountExtension returns the Unix account extension for the object or
 // nil.
 func (n *UserAccount) UNIXAccountExtension() *UNIXAccountExtension {

--- a/user.go
+++ b/user.go
@@ -4,7 +4,6 @@
 package stix2
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -72,9 +71,7 @@ func (n *UserAccount) UNIXAccountExtension() *UNIXAccountExtension {
 	if !ok {
 		return nil
 	}
-	var v UNIXAccountExtension
-	json.Unmarshal(data, &v)
-	return &v
+	return data.(*UNIXAccountExtension)
 }
 
 // NewUserAccount creates a new UserAccount object.
@@ -99,7 +96,7 @@ func NewUserAccount(opts ...STIXOption) (*UserAccount, error) {
 	if obj.AccountLogin != "" {
 		idContri = append(idContri, fmt.Sprintf(`"%s"`, obj.AccountLogin))
 	}
-	obj.ID = NewObservableIdenfier(fmt.Sprintf("[%s]", strings.Join(idContri, ",")), TypeUserAccount)
+	obj.ID = NewObservableIdentifier(fmt.Sprintf("[%s]", strings.Join(idContri, ",")), TypeUserAccount)
 	return obj, err
 }
 

--- a/user_test.go
+++ b/user_test.go
@@ -159,4 +159,36 @@ func TestUserAccount(t *testing.T) {
 		assert.Equal("the grugq", obj.DisplayName)
 		assert.Equal(AccountTwitter, obj.AccountType)
 	})
+
+	t.Run("parse-unix-user", func(t *testing.T) {
+		data := []byte(`{
+			"type": "user-account",
+			"spec_version": "2.1",
+			"id": "user-account--0d5b424b-93b8-5cd8-ac36-306e1789d63c",
+			"user_id": "1001",
+			"account_login": "jdoe",
+			"account_type": "unix",
+			"display_name": "John Doe",
+			"is_service_account": false,
+			"is_privileged": false,
+			"can_escalate_privs": true,
+			"extensions": {
+			  "unix-account-ext": {
+				"gid": 1001,
+				"groups": ["wheel"],
+				"home_dir": "/home/jdoe",
+				"shell": "/bin/bash"
+			  }
+			}
+		  }
+`)
+
+		var obj *UserAccount
+		err := json.Unmarshal(data, &obj)
+		assert.NoError(err)
+
+		ext := obj.UNIXAccountExtension()
+		assert.NotNil(ext)
+		assert.Equal(int64(1001), ext.GID)
+	})
 }

--- a/user_test.go
+++ b/user_test.go
@@ -39,7 +39,6 @@ func TestUserAccount(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 			//
 			OptionUserID(testStr),
 			OptionCredential(testStr),

--- a/vulnerability.go
+++ b/vulnerability.go
@@ -26,6 +26,10 @@ type Vulnerability struct {
 	Description string `json:"description,omitempty"`
 }
 
+func (o *Vulnerability) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewVulnerability creates a new Vulnerability object.
 func NewVulnerability(name string, opts ...STIXOption) (*Vulnerability, error) {
 	if name == "" {

--- a/x509.go
+++ b/x509.go
@@ -73,7 +73,7 @@ func NewX509Certificate(opts ...STIXOption) (*X509Certificate, error) {
 	if obj.SerialNumber != "" {
 		idContri = append(idContri, fmt.Sprintf(`"%s"`, obj.SerialNumber))
 	}
-	obj.ID = NewObservableIdenfier(fmt.Sprintf("[%s]", strings.Join(idContri, ",")), TypeX509Certificate)
+	obj.ID = NewObservableIdentifier(fmt.Sprintf("[%s]", strings.Join(idContri, ",")), TypeX509Certificate)
 	return obj, err
 }
 

--- a/x509.go
+++ b/x509.go
@@ -54,6 +54,10 @@ type X509Certificate struct {
 	X509v3Extensions X509v3Extension `json:"x509_v3_extensions,omitempty"`
 }
 
+func (o *X509Certificate) MarshalJSON() ([]byte, error) {
+	return marshalToJSONHelper(o)
+}
+
 // NewX509Certificate creates a new X509Certificate object.
 func NewX509Certificate(opts ...STIXOption) (*X509Certificate, error) {
 	if len(opts) == 0 {

--- a/x509_test.go
+++ b/x509_test.go
@@ -42,7 +42,6 @@ func TestX509Certificate(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionSpecVersion(specVer),
 			OptionDefanged(true),
-			OptionExtension("test", struct{}{}),
 			//
 			OptionSelfSigned(true),
 			OptionHashes(hashes),


### PR DESCRIPTION
This PR adds support for extensions as defined in the specification. It also includes handling for custom fields and objects that has been deprecated as part of STIX 2.1.

Fixes #15 and #12.