### PR TITLE
Add MarshalJSON method to EncryptionAlgorithm

### DIFF
--- a/artifact.go
+++ b/artifact.go
@@ -3,7 +3,10 @@
 
 package stix2
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // Artifact object permits capturing an array of bytes (8-bits), as a
 // base64-encoded string, or linking to a file-like payload. One of payload_bin
@@ -80,6 +83,11 @@ type EncryptionAlgorithm uint8
 // String returns the string representation of the type.
 func (typ EncryptionAlgorithm) String() string {
 	return encAlgMap[typ]
+}
+
+// MarshalJSON converts the enum type to the JSON string.
+func (typ EncryptionAlgorithm) MarshalJSON() ([]byte, error) {
+	return json.Marshal(typ.String())
 }
 
 // UnmarshalJSON extracts the encryption algorithm from the json data.

--- a/artifact_test.go
+++ b/artifact_test.go
@@ -153,4 +153,18 @@ func TestEncryptionAlgorithm(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(EncryptionAlgorithmNone, obj.Encryption)
 	})
+
+	t.Run("marshalJSON", func(t *testing.T) {
+		a, err := NewArtifact(
+			OptionHashes(Hashes{"SHA-256": "2cbb138d4097f05fffeb968b34a4e62884fc4755d7d043e2d3760950f1e1a9ee", "MD5": "0da609bd9ec46237557373f1c5cfcae9"}),
+			OptionKey("key"),
+			OptionPayload(Binary("Hello World")),
+			OptionEncryption(EncryptionAlgorithmChaCha20Poly1305),
+		)
+		assert.NoError(err)
+
+		data, err := json.Marshal(a)
+		assert.NoError(err)
+		assert.Contains(string(data), EncryptionAlgorithmChaCha20Poly1305.String())
+	})
 }


### PR DESCRIPTION
This fix ensures that the enum is marshalled to strings when serialized to JSON.