### PR TITLE
Add missing relationship types and fix COA helpers

### DIFF
--- a/course-of-action.go
+++ b/course-of-action.go
@@ -32,7 +32,7 @@ func (c *CourseOfAction) AddInvestigates(id Identifier, opts ...STIXOption) (*Re
 	if !IsValidIdentifier(id) || !id.ForType(TypeIndicator) {
 		return nil, ErrInvalidParameter
 	}
-	return NewRelationship(RelationshipTypeTargets, c.ID, id, opts...)
+	return NewRelationship(RelationshipTypeInvestigates, c.ID, id, opts...)
 }
 
 // AddMitigates creates a relationship to an attack pattern, indicator,
@@ -41,7 +41,7 @@ func (c *CourseOfAction) AddMitigates(id Identifier, opts ...STIXOption) (*Relat
 	if !IsValidIdentifier(id) || (!id.ForType(TypeAttackPattern) && !id.ForType(TypeIndicator) && !id.ForType(TypeMalware) && !id.ForType(TypeTool) && !id.ForType(TypeVulnerability)) {
 		return nil, ErrInvalidParameter
 	}
-	return NewRelationship(RelationshipTypeTargets, c.ID, id, opts...)
+	return NewRelationship(RelationshipTypeMitigates, c.ID, id, opts...)
 }
 
 // AddRemediates creates a relationship to a malware or a vulnerability that
@@ -50,7 +50,7 @@ func (c *CourseOfAction) AddRemediates(id Identifier, opts ...STIXOption) (*Rela
 	if !IsValidIdentifier(id) || (!id.ForType(TypeMalware) && !id.ForType(TypeVulnerability)) {
 		return nil, ErrInvalidParameter
 	}
-	return NewRelationship(RelationshipTypeTargets, c.ID, id, opts...)
+	return NewRelationship(RelationshipTypeRemediates, c.ID, id, opts...)
 }
 
 // NewCourseOfAction creates a new CourseOfAction object.

--- a/course-of-action_test.go
+++ b/course-of-action_test.go
@@ -113,6 +113,7 @@ func TestCourseOfActionMitigates(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(id, rel.Target)
 		assert.Equal(obj.ID, rel.Source)
+		assert.Equal(RelationshipTypeMitigates, rel.RelationshipType)
 	})
 
 	t.Run("indicator", func(t *testing.T) {
@@ -123,6 +124,7 @@ func TestCourseOfActionMitigates(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(id, rel.Target)
 		assert.Equal(obj.ID, rel.Source)
+		assert.Equal(RelationshipTypeMitigates, rel.RelationshipType)
 	})
 
 	t.Run("malware", func(t *testing.T) {
@@ -133,6 +135,7 @@ func TestCourseOfActionMitigates(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(id, rel.Target)
 		assert.Equal(obj.ID, rel.Source)
+		assert.Equal(RelationshipTypeMitigates, rel.RelationshipType)
 	})
 
 	t.Run("tool", func(t *testing.T) {
@@ -143,6 +146,7 @@ func TestCourseOfActionMitigates(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(id, rel.Target)
 		assert.Equal(obj.ID, rel.Source)
+		assert.Equal(RelationshipTypeMitigates, rel.RelationshipType)
 	})
 
 	t.Run("vulnerability", func(t *testing.T) {
@@ -153,6 +157,7 @@ func TestCourseOfActionMitigates(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(id, rel.Target)
 		assert.Equal(obj.ID, rel.Source)
+		assert.Equal(RelationshipTypeMitigates, rel.RelationshipType)
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
@@ -176,6 +181,7 @@ func TestCourseOfActionRemediates(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(id, rel.Target)
 		assert.Equal(obj.ID, rel.Source)
+		assert.Equal(RelationshipTypeRemediates, rel.RelationshipType)
 	})
 
 	t.Run("vulnerability", func(t *testing.T) {
@@ -186,6 +192,7 @@ func TestCourseOfActionRemediates(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(id, rel.Target)
 		assert.Equal(obj.ID, rel.Source)
+		assert.Equal(RelationshipTypeRemediates, rel.RelationshipType)
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {
@@ -209,6 +216,7 @@ func TestCourseOfActionAddInvestigates(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(id, rel.Target)
 		assert.Equal(obj.ID, rel.Source)
+		assert.Equal(RelationshipTypeInvestigates, rel.RelationshipType)
 	})
 
 	t.Run("invalid_type", func(t *testing.T) {

--- a/relationship.go
+++ b/relationship.go
@@ -132,6 +132,8 @@ const (
 	RelationshipTypeImpersonates RelationshipType = "impersonates"
 	// RelationshipTypeIndicates is an indicates relationship.
 	RelationshipTypeIndicates RelationshipType = "indicates"
+	// RelationshipTypeInvestigates is an indicates relationship.
+	RelationshipTypeInvestigates RelationshipType = "investigates"
 	// RelationshipTypeLocatedAt is a located at relationship.
 	RelationshipTypeLocatedAt RelationshipType = "located-at"
 	// RelationshipTypeMitigates is a mitigates relationship.
@@ -142,6 +144,8 @@ const (
 	RelationshipTypeOwns RelationshipType = "owns"
 	// RelationshipTypeRelatedTo is a related to relationship.
 	RelationshipTypeRelatedTo RelationshipType = "related-to"
+	// RelationshipTypeRemediates is a related to relationship.
+	RelationshipTypeRemediates RelationshipType = "remediates"
 	// RelationshipTypeResolvesTo is a resolves to relationship.
 	RelationshipTypeResolvesTo RelationshipType = "resolves-to"
 	// RelationshipTypeStaticAnalysisOf is a static analysis of relationship.


### PR DESCRIPTION
Add two missing relationship types. These were added late in the specification and was missed. Additionaly this fixes the helper functions for CoA to use the correct relationship types.

Fix #44 and #45.