### PR TITLE
adds region "south-eastern-asia"

### DIFF
--- a/location.go
+++ b/location.go
@@ -142,6 +142,8 @@ const (
 	RegionEasternAsia = "eastern-asia"
 	// RegionSouthernAsia is a region identifier for Southern Asia.
 	RegionSouthernAsia = "southern-asia"
+	// RegionSouthEasternAsia is a region identifier for South Eastern Asia
+	RegionSouthEasternAsia = "south-eastern-asia"
 	// RegionWesternAsia is a region identifier for Western Asia.
 	RegionWesternAsia = "western-asia"
 	// RegionEurope is a region identifier for Europe.


### PR DESCRIPTION
A small one to add the missing region "south-eastern-asia" as defined here: https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_i1sw27qw1v0s