### PR TITLE
timestamps in stix2 MUST be formatted as UTC

### DIFF
--- a/data-types.go
+++ b/data-types.go
@@ -438,7 +438,7 @@ type Timestamp struct {
 func (t *Timestamp) String() string {
 	// Go trims any trailing zeros, so instead of using the RFC3339Nano format,
 	// we use a modified version of it.
-	return t.Format("2006-01-02T15:04:05.000Z07:00")
+	return t.UTC().Format("2006-01-02T15:04:05.000Z07:00")
 }
 
 // MarshalJSON  creates a RFC 3339-formatted timestamp.

--- a/data-types_test.go
+++ b/data-types_test.go
@@ -243,6 +243,15 @@ func TestTimestamp(t *testing.T) {
 		assert.Contains(string(data), "2016-01-20T12:31:12.123Z")
 	})
 
+	t.Run("Marshal_always_utc", func(t *testing.T) {
+		tm := time.Date(2016, 1, 20, 13, 31, 12, 0, time.FixedZone("TEST", 3600))
+		s := struct{ Created *Timestamp }{Created: &Timestamp{tm}}
+		assert.Equal(2016, s.Created.Year())
+		data, err := json.Marshal(&s)
+		assert.NoError(err)
+		assert.Contains(string(data), "2016-01-20T12:31:12.000Z")
+	})
+
 	t.Run("Unmarshal_no_sub", func(t *testing.T) {
 		var s struct{ Created *Timestamp }
 		data := []byte(`{"created": "2016-01-20T12:31:12Z"}`)


### PR DESCRIPTION
When using Timestamps with a location other than UTC, the library currently marshals them "as is"

e.g. "2022-01-02T00:00:00+01:00" instead of "2022-01-01T23:00:00Z"

This change converts the timestamp to UTC before marshalling