### PR TITLE
fix(opinion): correctly formats opinion with string representation

### DIFF
--- a/opinion.go
+++ b/opinion.go
@@ -3,6 +3,8 @@
 
 package stix2
 
+import "fmt"
+
 // Opinion is an assessment of the correctness of the information in a STIX
 // Object produced by a different entity. The primary property is the opinion
 // property, which captures the level of agreement or disagreement using a
@@ -100,6 +102,10 @@ func (typ OpinionValue) String() string {
 		return ""
 	}
 	return val
+}
+
+func (typ OpinionValue) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, typ.String())), nil
 }
 
 // UnmarshalJSON extracts the OpinionValue from the json data.

--- a/opinion_test.go
+++ b/opinion_test.go
@@ -128,6 +128,25 @@ func TestOpinionValue(t *testing.T) {
 		}
 	})
 
+	t.Run("marshalJSON", func(t *testing.T) {
+		tests := []struct {
+			op  OpinionValue
+			str string
+		}{
+			{OpinionStronglyDisagree, `"strongly-disagree"`},
+			{OpinionDisagree, `"disagree"`},
+			{OpinionNeutral, `"neutral"`},
+			{OpinionAgree, `"agree"`},
+			{OpinionStronglyAgree, `"strongly-agree"`},
+			{OpinionValue(0), `""`},
+		}
+		for _, test := range tests {
+			j, err := test.op.MarshalJSON()
+			assert.NoError(err)
+			assert.Equal(test.str, string(j))
+		}
+	})
+
 	t.Run("unmarshalJSON", func(t *testing.T) {
 		tests := []struct {
 			op  OpinionValue


### PR DESCRIPTION
opinion was serialized with its enum representation (byte)