### PR TITLE
fix: makes observed data object_refs attribute optional

### DIFF
--- a/observed-data.go
+++ b/observed-data.go
@@ -84,8 +84,8 @@ func (o *ObservedData) MarshalJSON() ([]byte, error) {
 }
 
 // NewObservedData creates a new ObservedData object.
-func NewObservedData(firstObserved, lastObserved *Timestamp, numberObserved int64, objectsRef []Identifier, opts ...STIXOption) (*ObservedData, error) {
-	if len(objectsRef) == 0 || firstObserved == nil || lastObserved == nil || numberObserved < 1 {
+func NewObservedData(firstObserved, lastObserved *Timestamp, numberObserved int64, opts ...STIXOption) (*ObservedData, error) {
+	if firstObserved == nil || lastObserved == nil || numberObserved < 1 {
 		return nil, ErrPropertyMissing
 	}
 	base := newSTIXDomainObject(TypeObservedData)
@@ -94,7 +94,6 @@ func NewObservedData(firstObserved, lastObserved *Timestamp, numberObserved int6
 		FirstObserved:    firstObserved,
 		LastObserved:     lastObserved,
 		NumberObserved:   numberObserved,
-		ObjectRefs:       objectsRef,
 	}
 
 	err := applyOptions(obj, opts)

--- a/observed-data_test.go
+++ b/observed-data_test.go
@@ -20,13 +20,13 @@ func TestObservedData(t *testing.T) {
 	objs := []Identifier{Identifier("1"), Identifier("2")}
 
 	t.Run("missing_property", func(t *testing.T) {
-		obj, err := NewObservedData(nil, nil, int64(0), []Identifier{}, nil)
+		obj, err := NewObservedData(nil, nil, int64(0), nil)
 		assert.Nil(obj)
 		assert.Equal(ErrPropertyMissing, err)
 	})
 
 	t.Run("no_optional", func(t *testing.T) {
-		obj, err := NewObservedData(first, last, count, objs, nil)
+		obj, err := NewObservedData(first, last, count, nil)
 		assert.NotNil(obj)
 		assert.NoError(err)
 	})
@@ -54,8 +54,9 @@ func TestObservedData(t *testing.T) {
 			OptionObjectMarking(objmark),
 			OptionRevoked(true),
 			OptionSpecVersion(specVer),
+			OptionObjectRefs(objs),
 		}
-		obj, err := NewObservedData(first, last, count, objs, opts...)
+		obj, err := NewObservedData(first, last, count, opts...)
 		assert.NotNil(obj)
 		assert.NoError(err)
 		assert.Equal(conf, obj.Confidence)

--- a/option.go
+++ b/option.go
@@ -1443,6 +1443,14 @@ func OptionObjectModified(s *Timestamp) STIXOption {
 	}
 }
 
+// OptionObjectRefs sets the object_refs attribute. This option is valid for the types:
+//   - ObservedData
+func OptionObjectRefs(objects []Identifier) STIXOption {
+	return func(obj STIXObject) error {
+		return setField(obj, "ObjectRefs", objects, reflect.Slice)
+	}
+}
+
 /*
 	Helper functions
 */


### PR DESCRIPTION
Observed Data attribute object_refs is optional and should be removed from the constructor